### PR TITLE
feat: Sort equipment and localcontact list based on selected instrument

### DIFF
--- a/apps/e2e/cypress/e2e/calendar.cy.ts
+++ b/apps/e2e/cypress/e2e/calendar.cy.ts
@@ -37,7 +37,7 @@ context('Calendar tests', () => {
     cy.visit('/calendar');
   });
 
-  describe('Calendar navigation', () => {
+  describe.skip('Calendar navigation', () => {
     it('should save calendar state when navigating inside the app but not when reload and visit /calendar', () => {
       cy.finishedLoading();
       selectInstrument();
@@ -351,8 +351,6 @@ context('Calendar tests', () => {
       selectInstrument(initialDBData.instruments[0].name);
 
       cy.finishedLoading();
-
-      cy.get('[data-cy=input-instrument-select]').should('contain.text', '+1');
 
       const slot = new Date(defaultEventBookingHourDateTime).toISOString();
       cy.get(`.rbc-day-slot [data-cy='event-slot-${slot}']`).should('exist');

--- a/apps/e2e/cypress/e2e/calendar.cy.ts
+++ b/apps/e2e/cypress/e2e/calendar.cy.ts
@@ -37,7 +37,7 @@ context('Calendar tests', () => {
     cy.visit('/calendar');
   });
 
-  describe.skip('Calendar navigation', () => {
+  describe('Calendar navigation', () => {
     it('should save calendar state when navigating inside the app but not when reload and visit /calendar', () => {
       cy.finishedLoading();
       selectInstrument();

--- a/apps/e2e/cypress/e2e/calendar.cy.ts
+++ b/apps/e2e/cypress/e2e/calendar.cy.ts
@@ -1,3 +1,4 @@
+import { faker } from '@faker-js/faker';
 import { ScheduledEventBookingType } from '@user-office-software-libs/shared-types';
 import moment from 'moment';
 
@@ -12,6 +13,14 @@ import {
   TZ_LESS_DATE_TIME_LOW_PREC_FORMAT,
   getHourDateTimeAfterWithoutSpaces,
 } from '../utils';
+
+const newEquipment = {
+  name: faker.random.words(2),
+  description: '',
+  autoAccept: false,
+  ownerUserId: 1,
+  instrumentIds: [1],
+};
 
 function clickOnEventSlot(slot: string) {
   cy.get(`.rbc-day-slot [data-cy='event-slot-${slot}']`).then(($el) => {
@@ -482,6 +491,41 @@ context('Calendar tests', () => {
       cy.get(
         `.rbc-day-slot .rbc-background-event [data-cy='event-${slot}']`
       ).should('not.exist');
+    });
+  });
+  describe('Calendar dropdown list sorting', () => {
+    const instrumentScientistUserName = `${initialDBData.users.instrumentScientist1.firstname} ${initialDBData.users.instrumentScientist1.lastname}`;
+
+    it('should be able to sort Equipment and Local contact list based on selected instruments', () => {
+      cy.createEquipment({ newEquipmentInput: newEquipment });
+
+      cy.login('officer');
+      cy.visit('/calendar');
+      cy.finishedLoading();
+
+      selectInstrument(initialDBData.instruments[0].name);
+
+      cy.get('[data-cy=input-equipment-select]').click();
+
+      cy.get('[aria-labelledby=input-equipment-select-label] [role=option]')
+        .first()
+        .should('contain', newEquipment.name);
+
+      cy.get(
+        '[aria-labelledby=input-equipment-select-label] [role=option]'
+      ).each((element, index) => {
+        if (index < 5) {
+          cy.wrap(element).click();
+        }
+      });
+      cy.get('[data-cy=input-equipment-select]').should('contain.text', '+1');
+
+      cy.get('[data-cy=input-local-contact-select]').click();
+
+      cy.get('[aria-labelledby=input-local-contact-select-label] [role=option]')
+        .first()
+        .should('contain', instrumentScientistUserName)
+        .click();
     });
   });
 });

--- a/apps/e2e/cypress/support/initialDBData.ts
+++ b/apps/e2e/cypress/support/initialDBData.ts
@@ -58,11 +58,15 @@ export default {
       id: 100,
       email: 'instr.sci1@local.host',
       password: 'Test1234!',
+      firstname: 'Instrument',
+      lastname: 'Scientist1',
     },
     instrumentScientist2: {
       id: 101,
       email: 'instr.sci2@local.host',
       password: 'Test1234!',
+      firstname: 'Instrument',
+      lastname: 'Scientist2',
     },
   },
 };

--- a/apps/e2e/cypress/utils/index.ts
+++ b/apps/e2e/cypress/utils/index.ts
@@ -90,7 +90,11 @@ export const getFormattedEndOfSelectedWeek = (selectedWeek = 0) => {
 export const selectInstrument = (instrument?: string) => {
   cy.get('[data-cy=input-instrument-select] input').should('not.be.disabled');
 
-  cy.get('[data-cy=input-instrument-select] [aria-label="Open"]').click();
+  cy.get('[data-cy=input-instrument-select]').then((body) => {
+    if (body.find('[aria-label="Open"]').length > 0) {
+      cy.get('[data-cy=input-instrument-select] [aria-label="Open"]').click();
+    }
+  });
 
   if (instrument) {
     cy.get('[aria-labelledby=input-instrument-select-label] [role=option]')

--- a/apps/frontend/src/components/calendar/common/InstrumentAndEquipmentFilter.tsx
+++ b/apps/frontend/src/components/calendar/common/InstrumentAndEquipmentFilter.tsx
@@ -338,24 +338,22 @@ export default function InstrumentAndEquipmentFilter({
             ).equipmentInstruments?.map((instrument) => instrument.name);
 
             return (
-              <>
-                <li {...props}>
-                  <Checkbox style={{ marginRight: 8 }} checked={selected} />
-                  <div>
-                    <div>{option.name}</div>
-                    {relatedInstruments && relatedInstruments?.length > 0 && (
-                      <div
-                        style={{
-                          fontSize: '12px',
-                        }}
-                      >
-                        Instrument: {relatedInstruments?.join(',')}
-                      </div>
-                    )}
-                    {}
-                  </div>
-                </li>
-              </>
+              <li {...props}>
+                <Checkbox style={{ marginRight: 8 }} checked={selected} />
+                <div>
+                  <div>{option.name}</div>
+                  {relatedInstruments && relatedInstruments?.length > 0 && (
+                    <div
+                      style={{
+                        fontSize: '12px',
+                      }}
+                    >
+                      Instrument: {relatedInstruments?.join(',')}
+                    </div>
+                  )}
+                  {}
+                </div>
+              </li>
             );
           }}
           renderInput={(params) => (

--- a/apps/frontend/src/components/calendar/common/InstrumentAndEquipmentFilter.tsx
+++ b/apps/frontend/src/components/calendar/common/InstrumentAndEquipmentFilter.tsx
@@ -398,7 +398,6 @@ export default function InstrumentAndEquipmentFilter({
                       Instrument: {equipmentNameList?.join(',')}
                     </div>
                   )}
-                  {}
                 </div>
               </ListItem>
             );

--- a/apps/frontend/src/components/calendar/common/InstrumentAndEquipmentFilter.tsx
+++ b/apps/frontend/src/components/calendar/common/InstrumentAndEquipmentFilter.tsx
@@ -200,9 +200,7 @@ export default function InstrumentAndEquipmentFilter({
       return equipments;
     }
     const selectedInstruments = new Set(
-      (selectedInstrument as PartialInstrument[]).map(
-        (inst: PartialInstrument) => inst.name
-      )
+      (selectedInstrument as PartialInstrument[]).map((inst) => inst.name)
     );
 
     const sortedEquipments = [...equipments].sort((a, b) => {
@@ -220,6 +218,37 @@ export default function InstrumentAndEquipmentFilter({
     });
 
     return sortedEquipments;
+  };
+
+  const sortLocalContacts = (
+    localContacts: BasicUserDetailsFragment[],
+    selectedInstrument: PartialInstrument | PartialInstrument[] | null
+  ) => {
+    if (!selectedInstrument) {
+      return localContacts;
+    }
+    const selectedInstruments = (selectedInstrument as PartialInstrument[]).map(
+      (inst) => {
+        return inst.scientists?.map(
+          (scientist: { id: number }) => scientist.id
+        );
+      }
+    );
+    const sortedlocalContacts = localContacts?.sort((a, b) => {
+      const aContains = selectedInstruments.some((item) =>
+        item?.includes(a.id)
+      );
+      const bContains = selectedInstruments.some((item) =>
+        item?.includes(b.id)
+      );
+
+      if (aContains === bContains) return 0;
+      if (aContains) return -1;
+
+      return 1;
+    });
+
+    return sortedlocalContacts;
   };
 
   // NOTE: Limited tags rendering to save some space and it looks a bit ugly when too many items are selected on the autocomplete.
@@ -400,7 +429,7 @@ export default function InstrumentAndEquipmentFilter({
           clearOnBlur
           fullWidth
           handleHomeEndKeys
-          options={localContacts}
+          options={sortLocalContacts(localContacts, selectedInstrument)}
           getOptionLabel={(localContact) =>
             `${localContact.firstname} ${localContact.lastname}`
           }

--- a/apps/frontend/src/components/calendar/common/InstrumentAndEquipmentFilter.tsx
+++ b/apps/frontend/src/components/calendar/common/InstrumentAndEquipmentFilter.tsx
@@ -7,6 +7,7 @@ import {
   TextField,
   Autocomplete,
   Checkbox,
+  ListItem,
 } from '@mui/material';
 import React, { useContext, useEffect, useState } from 'react';
 import { useHistory } from 'react-router';
@@ -22,6 +23,9 @@ import { getFullUserName } from 'utils/user';
 const useStyles = makeStyles()((theme) => ({
   root: {
     marginBottom: theme.spacing(1),
+  },
+  highlight: {
+    backgroundColor: 'rgba(255, 255, 255, 0.7)',
   },
 }));
 
@@ -311,10 +315,10 @@ export default function InstrumentAndEquipmentFilter({
           data-cy="input-instrument-select"
           id="input-instrument-select"
           renderOption={(props, option, { selected }) => (
-            <li {...props} style={{ height: 34 }}>
+            <ListItem {...props} style={{ height: 34 }}>
               <Checkbox style={{ marginRight: 8 }} checked={selected} />
               {option.name}
-            </li>
+            </ListItem>
           )}
           renderInput={(params) => (
             <TextField
@@ -362,27 +366,41 @@ export default function InstrumentAndEquipmentFilter({
           data-cy="input-equipment-select"
           id="input-equipment-select"
           renderOption={(props, option, { selected }) => {
-            const relatedInstruments = (
+            const equipmentNameList = (
               option as Equipment
             ).equipmentInstruments?.map((instrument) => instrument.name);
 
+            const equipmentIdList = (
+              option as Equipment
+            ).equipmentInstruments?.map((instrument) => instrument.id);
+
+            const hasEquipmentSelectedInstrument = (
+              selectedInstrument as Array<PartialInstrument>
+            )?.some((instrument) => equipmentIdList?.includes(instrument.id));
+
+            const highlightStyle =
+              hasEquipmentSelectedInstrument ||
+              (selectedInstrument as Array<PartialInstrument>).length < 1
+                ? {}
+                : { opacity: '0.6' };
+
             return (
-              <li {...props}>
+              <ListItem {...props} style={highlightStyle}>
                 <Checkbox style={{ marginRight: 8 }} checked={selected} />
                 <div>
                   <div>{option.name}</div>
-                  {relatedInstruments && relatedInstruments?.length > 0 && (
+                  {equipmentNameList && equipmentNameList?.length > 0 && (
                     <div
                       style={{
                         fontSize: '12px',
                       }}
                     >
-                      Instrument: {relatedInstruments?.join(',')}
+                      Instrument: {equipmentNameList?.join(',')}
                     </div>
                   )}
                   {}
                 </div>
-              </li>
+              </ListItem>
             );
           }}
           renderInput={(params) => (
@@ -436,12 +454,29 @@ export default function InstrumentAndEquipmentFilter({
           disableCloseOnSelect
           data-cy="input-local-contact-select"
           id="input-local-contact-select"
-          renderOption={(props, option, { selected }) => (
-            <li {...props} style={{ height: 34 }}>
-              <Checkbox style={{ marginRight: 8 }} checked={selected} />
-              {`${option.firstname} ${option.lastname}`}
-            </li>
-          )}
+          renderOption={(props, option, { selected }) => {
+            const localContactId = option.id;
+            const hasEquipmentSelectedInstrument = (
+              selectedInstrument as Array<PartialInstrument>
+            ).some((targetInstrument) =>
+              targetInstrument.scientists?.some(
+                (scientist) => scientist.id === localContactId
+              )
+            );
+
+            const highlightStyle =
+              hasEquipmentSelectedInstrument ||
+              (selectedInstrument as Array<PartialInstrument>).length < 1
+                ? {}
+                : { opacity: '0.6' };
+
+            return (
+              <li {...props} style={{ ...highlightStyle, height: 34 }}>
+                <Checkbox style={{ marginRight: 8 }} checked={selected} />
+                {`${option.firstname} ${option.lastname}`}
+              </li>
+            );
+          }}
           renderInput={(params) => (
             <TextField
               {...params}

--- a/apps/frontend/src/generated/sdk.ts
+++ b/apps/frontend/src/generated/sdk.ts
@@ -10,7 +10,7 @@ export type MakeEmpty<T extends { [key: string]: unknown }, K extends keyof T> =
 export type Incremental<T> = T | { [P in keyof T]?: P extends ' $fragmentName' | '__typename' ? T[P] : never };
 /** All built-in and custom scalars, mapped to their actual values */
 export type Scalars = {
-  ID: { input: string | number; output: string; }
+  ID: { input: string; output: string; }
   String: { input: string; output: string; }
   Boolean: { input: boolean; output: boolean; }
   Int: { input: number; output: number; }
@@ -90,9 +90,14 @@ export type AnswerInput = {
   value?: InputMaybe<Scalars['String']['input']>;
 };
 
-export type AssignChairOrSecretaryToSepInput = {
+export type ApiCallRequestHeader = {
+  name: Scalars['String']['output'];
+  value: Scalars['String']['output'];
+};
+
+export type AssignChairOrSecretaryToFapInput = {
+  fapId: Scalars['Int']['input'];
   roleId: UserRole;
-  sepId: Scalars['Int']['input'];
   userId: Scalars['Int']['input'];
 };
 
@@ -104,7 +109,7 @@ export type AssignEquipmentsToScheduledEventInput = {
 
 export type AssignInstrumentsToCallInput = {
   callId: Scalars['Int']['input'];
-  instrumentSepIds: Array<InstrumentSepMappingInput>;
+  instrumentFapIds: Array<InstrumentFapMappingInput>;
 };
 
 export type AuthJwtApiTokenPayload = {
@@ -143,10 +148,11 @@ export type Call = {
   endCall: Scalars['DateTime']['output'];
   endCallInternal: Maybe<Scalars['DateTime']['output']>;
   endCycle: Scalars['DateTime']['output'];
+  endFapReview: Maybe<Scalars['DateTime']['output']>;
   endNotify: Scalars['DateTime']['output'];
   endReview: Scalars['DateTime']['output'];
-  endSEPReview: Maybe<Scalars['DateTime']['output']>;
   esiTemplateId: Maybe<Scalars['Int']['output']>;
+  faps: Maybe<Array<Fap>>;
   id: Scalars['Int']['output'];
   instruments: Array<InstrumentWithAvailabilityTime>;
   isActive: Scalars['Boolean']['output'];
@@ -157,13 +163,12 @@ export type Call = {
   proposalWorkflow: Maybe<ProposalWorkflow>;
   proposalWorkflowId: Maybe<Scalars['Int']['output']>;
   referenceNumberFormat: Maybe<Scalars['String']['output']>;
-  seps: Maybe<Array<Sep>>;
   shortCode: Scalars['String']['output'];
   startCall: Scalars['DateTime']['output'];
   startCycle: Scalars['DateTime']['output'];
+  startFapReview: Maybe<Scalars['DateTime']['output']>;
   startNotify: Scalars['DateTime']['output'];
   startReview: Scalars['DateTime']['output'];
-  startSEPReview: Maybe<Scalars['DateTime']['output']>;
   submissionMessage: Maybe<Scalars['String']['output']>;
   surveyComment: Scalars['String']['output'];
   template: Template;
@@ -172,15 +177,16 @@ export type Call = {
 };
 
 export type CallsFilter = {
+  fapIds?: InputMaybe<Array<Scalars['Int']['input']>>;
+  instrumentIds?: InputMaybe<Array<Scalars['Int']['input']>>;
   isActive?: InputMaybe<Scalars['Boolean']['input']>;
   isActiveInternal?: InputMaybe<Scalars['Boolean']['input']>;
   isCallEndedByEvent?: InputMaybe<Scalars['Boolean']['input']>;
   isEnded?: InputMaybe<Scalars['Boolean']['input']>;
   isEndedInternal?: InputMaybe<Scalars['Boolean']['input']>;
+  isFapReviewEnded?: InputMaybe<Scalars['Boolean']['input']>;
   isReviewEnded?: InputMaybe<Scalars['Boolean']['input']>;
-  isSEPReviewEnded?: InputMaybe<Scalars['Boolean']['input']>;
   pdfTemplateIds?: InputMaybe<Array<Scalars['Int']['input']>>;
-  sepIds?: InputMaybe<Array<Scalars['Int']['input']>>;
   templateIds?: InputMaybe<Array<Scalars['Int']['input']>>;
 };
 
@@ -222,7 +228,6 @@ export type ConnectionStatusAction = {
   actionId: Scalars['Int']['output'];
   config: Maybe<ProposalStatusActionConfig>;
   connectionId: Scalars['Int']['output'];
-  executed: Scalars['Boolean']['output'];
   workflowId: Scalars['Int']['output'];
 };
 
@@ -243,21 +248,21 @@ export type CreateCallInput = {
   endCall: Scalars['DateTime']['input'];
   endCallInternal?: InputMaybe<Scalars['DateTime']['input']>;
   endCycle: Scalars['DateTime']['input'];
+  endFapReview?: InputMaybe<Scalars['DateTime']['input']>;
   endNotify: Scalars['DateTime']['input'];
   endReview: Scalars['DateTime']['input'];
-  endSEPReview?: InputMaybe<Scalars['DateTime']['input']>;
   esiTemplateId?: InputMaybe<Scalars['Int']['input']>;
+  faps?: InputMaybe<Array<Scalars['Int']['input']>>;
   pdfTemplateId?: InputMaybe<Scalars['Int']['input']>;
   proposalSequence?: InputMaybe<Scalars['Int']['input']>;
   proposalWorkflowId: Scalars['Int']['input'];
   referenceNumberFormat?: InputMaybe<Scalars['String']['input']>;
-  seps?: InputMaybe<Array<Scalars['Int']['input']>>;
   shortCode: Scalars['String']['input'];
   startCall: Scalars['DateTime']['input'];
   startCycle: Scalars['DateTime']['input'];
+  startFapReview?: InputMaybe<Scalars['DateTime']['input']>;
   startNotify: Scalars['DateTime']['input'];
   startReview: Scalars['DateTime']['input'];
-  startSEPReview?: InputMaybe<Scalars['DateTime']['input']>;
   submissionMessage?: InputMaybe<Scalars['String']['input']>;
   surveyComment: Scalars['String']['input'];
   templateId: Scalars['Int']['input'];
@@ -369,10 +374,10 @@ export enum DependenciesLogicOperator {
 }
 
 export type DynamicMultipleChoiceConfig = {
+  apiCallRequestHeaders: Array<ApiCallRequestHeader>;
   externalApiCall: Scalars['Boolean']['output'];
   isMultipleSelect: Scalars['Boolean']['output'];
   jsonPath: Scalars['String']['output'];
-  options: Array<Scalars['String']['output']>;
   required: Scalars['Boolean']['output'];
   small_label: Scalars['String']['output'];
   tooltip: Scalars['String']['output'];
@@ -401,10 +406,10 @@ export type EmailStatusActionRecipient = {
 
 export enum EmailStatusActionRecipients {
   CO_PROPOSERS = 'CO_PROPOSERS',
+  FAP_REVIEWERS = 'FAP_REVIEWERS',
   INSTRUMENT_SCIENTISTS = 'INSTRUMENT_SCIENTISTS',
   OTHER = 'OTHER',
-  PI = 'PI',
-  SEP_REVIEWERS = 'SEP_REVIEWERS'
+  PI = 'PI'
 }
 
 export type EmailStatusActionRecipientsWithTemplate = {
@@ -501,9 +506,17 @@ export enum Event {
   CALL_CREATED = 'CALL_CREATED',
   CALL_ENDED = 'CALL_ENDED',
   CALL_ENDED_INTERNAL = 'CALL_ENDED_INTERNAL',
+  CALL_FAP_REVIEW_ENDED = 'CALL_FAP_REVIEW_ENDED',
   CALL_REVIEW_ENDED = 'CALL_REVIEW_ENDED',
-  CALL_SEP_REVIEW_ENDED = 'CALL_SEP_REVIEW_ENDED',
   EMAIL_INVITE = 'EMAIL_INVITE',
+  FAP_CREATED = 'FAP_CREATED',
+  FAP_MEMBERS_ASSIGNED = 'FAP_MEMBERS_ASSIGNED',
+  FAP_MEMBER_ASSIGNED_TO_PROPOSAL = 'FAP_MEMBER_ASSIGNED_TO_PROPOSAL',
+  FAP_MEMBER_REMOVED = 'FAP_MEMBER_REMOVED',
+  FAP_MEMBER_REMOVED_FROM_PROPOSAL = 'FAP_MEMBER_REMOVED_FROM_PROPOSAL',
+  FAP_PROPOSAL_REMOVED = 'FAP_PROPOSAL_REMOVED',
+  FAP_REVIEWER_NOTIFIED = 'FAP_REVIEWER_NOTIFIED',
+  FAP_UPDATED = 'FAP_UPDATED',
   INSTRUMENT_ASSIGNED_TO_SCIENTIST = 'INSTRUMENT_ASSIGNED_TO_SCIENTIST',
   INSTRUMENT_CREATED = 'INSTRUMENT_CREATED',
   INSTRUMENT_DELETED = 'INSTRUMENT_DELETED',
@@ -515,8 +528,8 @@ export enum Event {
   PREDEFINED_MESSAGE_DELETED = 'PREDEFINED_MESSAGE_DELETED',
   PREDEFINED_MESSAGE_UPDATED = 'PREDEFINED_MESSAGE_UPDATED',
   PROPOSAL_ACCEPTED = 'PROPOSAL_ACCEPTED',
-  PROPOSAL_ALL_SEP_REVIEWERS_SELECTED = 'PROPOSAL_ALL_SEP_REVIEWERS_SELECTED',
-  PROPOSAL_ALL_SEP_REVIEWS_SUBMITTED = 'PROPOSAL_ALL_SEP_REVIEWS_SUBMITTED',
+  PROPOSAL_ALL_FAP_REVIEWERS_SELECTED = 'PROPOSAL_ALL_FAP_REVIEWERS_SELECTED',
+  PROPOSAL_ALL_FAP_REVIEWS_SUBMITTED = 'PROPOSAL_ALL_FAP_REVIEWS_SUBMITTED',
   PROPOSAL_BOOKING_TIME_ACTIVATED = 'PROPOSAL_BOOKING_TIME_ACTIVATED',
   PROPOSAL_BOOKING_TIME_COMPLETED = 'PROPOSAL_BOOKING_TIME_COMPLETED',
   PROPOSAL_BOOKING_TIME_REOPENED = 'PROPOSAL_BOOKING_TIME_REOPENED',
@@ -526,6 +539,13 @@ export enum Event {
   PROPOSAL_CLONED = 'PROPOSAL_CLONED',
   PROPOSAL_CREATED = 'PROPOSAL_CREATED',
   PROPOSAL_DELETED = 'PROPOSAL_DELETED',
+  PROPOSAL_FAP_MEETING_RANKING_OVERWRITTEN = 'PROPOSAL_FAP_MEETING_RANKING_OVERWRITTEN',
+  PROPOSAL_FAP_MEETING_REORDER = 'PROPOSAL_FAP_MEETING_REORDER',
+  PROPOSAL_FAP_MEETING_SAVED = 'PROPOSAL_FAP_MEETING_SAVED',
+  PROPOSAL_FAP_MEETING_SUBMITTED = 'PROPOSAL_FAP_MEETING_SUBMITTED',
+  PROPOSAL_FAP_REVIEW_SUBMITTED = 'PROPOSAL_FAP_REVIEW_SUBMITTED',
+  PROPOSAL_FAP_REVIEW_UPDATED = 'PROPOSAL_FAP_REVIEW_UPDATED',
+  PROPOSAL_FAP_SELECTED = 'PROPOSAL_FAP_SELECTED',
   PROPOSAL_FEASIBILITY_REVIEW_SUBMITTED = 'PROPOSAL_FEASIBILITY_REVIEW_SUBMITTED',
   PROPOSAL_FEASIBILITY_REVIEW_UPDATED = 'PROPOSAL_FEASIBILITY_REVIEW_UPDATED',
   PROPOSAL_FEASIBLE = 'PROPOSAL_FEASIBLE',
@@ -538,27 +558,12 @@ export enum Event {
   PROPOSAL_RESERVED = 'PROPOSAL_RESERVED',
   PROPOSAL_SAMPLE_REVIEW_SUBMITTED = 'PROPOSAL_SAMPLE_REVIEW_SUBMITTED',
   PROPOSAL_SAMPLE_SAFE = 'PROPOSAL_SAMPLE_SAFE',
-  PROPOSAL_SEP_MEETING_RANKING_OVERWRITTEN = 'PROPOSAL_SEP_MEETING_RANKING_OVERWRITTEN',
-  PROPOSAL_SEP_MEETING_REORDER = 'PROPOSAL_SEP_MEETING_REORDER',
-  PROPOSAL_SEP_MEETING_SAVED = 'PROPOSAL_SEP_MEETING_SAVED',
-  PROPOSAL_SEP_MEETING_SUBMITTED = 'PROPOSAL_SEP_MEETING_SUBMITTED',
-  PROPOSAL_SEP_REVIEW_SUBMITTED = 'PROPOSAL_SEP_REVIEW_SUBMITTED',
-  PROPOSAL_SEP_REVIEW_UPDATED = 'PROPOSAL_SEP_REVIEW_UPDATED',
-  PROPOSAL_SEP_SELECTED = 'PROPOSAL_SEP_SELECTED',
   PROPOSAL_STATUS_ACTION_EXECUTED = 'PROPOSAL_STATUS_ACTION_EXECUTED',
   PROPOSAL_STATUS_CHANGED_BY_USER = 'PROPOSAL_STATUS_CHANGED_BY_USER',
   PROPOSAL_STATUS_CHANGED_BY_WORKFLOW = 'PROPOSAL_STATUS_CHANGED_BY_WORKFLOW',
   PROPOSAL_SUBMITTED = 'PROPOSAL_SUBMITTED',
   PROPOSAL_UNFEASIBLE = 'PROPOSAL_UNFEASIBLE',
   PROPOSAL_UPDATED = 'PROPOSAL_UPDATED',
-  SEP_CREATED = 'SEP_CREATED',
-  SEP_MEMBERS_ASSIGNED = 'SEP_MEMBERS_ASSIGNED',
-  SEP_MEMBER_ASSIGNED_TO_PROPOSAL = 'SEP_MEMBER_ASSIGNED_TO_PROPOSAL',
-  SEP_MEMBER_REMOVED = 'SEP_MEMBER_REMOVED',
-  SEP_MEMBER_REMOVED_FROM_PROPOSAL = 'SEP_MEMBER_REMOVED_FROM_PROPOSAL',
-  SEP_PROPOSAL_REMOVED = 'SEP_PROPOSAL_REMOVED',
-  SEP_REVIEWER_NOTIFIED = 'SEP_REVIEWER_NOTIFIED',
-  SEP_UPDATED = 'SEP_UPDATED',
   TOPIC_ANSWERED = 'TOPIC_ANSWERED',
   USER_DELETED = 'USER_DELETED',
   USER_PASSWORD_RESET_EMAIL = 'USER_PASSWORD_RESET_EMAIL',
@@ -567,8 +572,9 @@ export enum Event {
 }
 
 export type EventLog = {
-  changedBy: User;
+  changedBy: Maybe<User>;
   changedObjectId: Scalars['String']['output'];
+  description: Scalars['String']['output'];
   eventTStamp: Scalars['DateTime']['output'];
   eventType: Scalars['String']['output'];
   id: Scalars['Int']['output'];
@@ -591,6 +597,76 @@ export type ExternalTokenResult = {
   isValid: Scalars['Boolean']['output'];
 };
 
+export type Fap = {
+  active: Scalars['Boolean']['output'];
+  code: Scalars['String']['output'];
+  customGradeGuide: Maybe<Scalars['Boolean']['output']>;
+  description: Scalars['String']['output'];
+  fapChair: Maybe<BasicUserDetails>;
+  fapChairProposalCount: Maybe<Scalars['Int']['output']>;
+  fapSecretary: Maybe<BasicUserDetails>;
+  fapSecretaryProposalCount: Maybe<Scalars['Int']['output']>;
+  gradeGuide: Maybe<Scalars['String']['output']>;
+  id: Scalars['Int']['output'];
+  numberRatingsRequired: Scalars['Float']['output'];
+  proposalCount: Scalars['Int']['output'];
+};
+
+export type FapAssignment = {
+  dateAssigned: Scalars['DateTime']['output'];
+  dateReassigned: Maybe<Scalars['DateTime']['output']>;
+  emailSent: Scalars['Boolean']['output'];
+  fapId: Scalars['Int']['output'];
+  fapMemberUserId: Maybe<Scalars['Int']['output']>;
+  proposal: Proposal;
+  proposalPk: Scalars['Int']['output'];
+  reassigned: Scalars['Boolean']['output'];
+  review: Maybe<Review>;
+  role: Maybe<Role>;
+  user: Maybe<BasicUserDetails>;
+};
+
+export type FapMeetingDecision = {
+  commentForManagement: Maybe<Scalars['String']['output']>;
+  commentForUser: Maybe<Scalars['String']['output']>;
+  proposalPk: Scalars['Int']['output'];
+  rankOrder: Maybe<Scalars['Int']['output']>;
+  recommendation: Maybe<ProposalEndStatus>;
+  submitted: Scalars['Boolean']['output'];
+  submittedBy: Maybe<Scalars['Int']['output']>;
+};
+
+export type FapProposal = {
+  assignments: Maybe<Array<FapAssignment>>;
+  dateAssigned: Scalars['DateTime']['output'];
+  fapId: Scalars['Int']['output'];
+  fapTimeAllocation: Maybe<Scalars['Int']['output']>;
+  instrumentSubmitted: Scalars['Boolean']['output'];
+  proposal: Proposal;
+  proposalPk: Scalars['Int']['output'];
+};
+
+export type FapReviewer = {
+  fapId: Scalars['Int']['output'];
+  proposalsCount: Scalars['Int']['output'];
+  role: Maybe<Role>;
+  user: BasicUserDetails;
+  userId: Scalars['Int']['output'];
+};
+
+export type FapsFilter = {
+  active?: InputMaybe<Scalars['Boolean']['input']>;
+  callIds?: InputMaybe<Array<Scalars['Int']['input']>>;
+  filter?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+};
+
+export type FapsQueryResult = {
+  faps: Array<Fap>;
+  totalCount: Scalars['Int']['output'];
+};
+
 export type Feature = {
   description: Scalars['String']['output'];
   id: FeatureId;
@@ -600,12 +676,12 @@ export type Feature = {
 export enum FeatureId {
   EMAIL_INVITE = 'EMAIL_INVITE',
   EMAIL_SEARCH = 'EMAIL_SEARCH',
+  FAP_REVIEW = 'FAP_REVIEW',
   INSTRUMENT_MANAGEMENT = 'INSTRUMENT_MANAGEMENT',
   OAUTH = 'OAUTH',
   RISK_ASSESSMENT = 'RISK_ASSESSMENT',
   SAMPLE_SAFETY = 'SAMPLE_SAFETY',
   SCHEDULER = 'SCHEDULER',
-  SEP_REVIEW = 'SEP_REVIEW',
   SHIPPING = 'SHIPPING',
   STFC_IDLE_TIMER = 'STFC_IDLE_TIMER',
   TECHNICAL_REVIEW = 'TECHNICAL_REVIEW',
@@ -759,6 +835,11 @@ export type Instrument = {
   shortCode: Scalars['String']['output'];
 };
 
+export type InstrumentFapMappingInput = {
+  fapId?: InputMaybe<Scalars['Int']['input']>;
+  instrumentId: Scalars['Int']['input'];
+};
+
 export type InstrumentOption = {
   id: Scalars['Float']['output'];
   name: Scalars['String']['output'];
@@ -772,21 +853,16 @@ export type InstrumentPickerConfig = {
   variant: Scalars['String']['output'];
 };
 
-export type InstrumentSepMappingInput = {
-  instrumentId: Scalars['Int']['input'];
-  sepId?: InputMaybe<Scalars['Int']['input']>;
-};
-
 export type InstrumentWithAvailabilityTime = {
   availabilityTime: Maybe<Scalars['Int']['output']>;
   beamlineManager: Maybe<BasicUserDetails>;
   description: Scalars['String']['output'];
+  fap: Maybe<Fap>;
+  fapId: Maybe<Scalars['Int']['output']>;
   id: Scalars['Int']['output'];
   managerUserId: Scalars['Int']['output'];
   name: Scalars['String']['output'];
   scientists: Array<BasicUserDetails>;
-  sep: Maybe<Sep>;
-  sepId: Maybe<Scalars['Int']['output']>;
   shortCode: Scalars['String']['output'];
   submitted: Scalars['Boolean']['output'];
 };
@@ -857,13 +933,13 @@ export type Mutation = {
   administrationProposal: Proposal;
   answerTopic: QuestionaryStep;
   applyPatches: Array<Scalars['String']['output']>;
-  assignChairOrSecretary: Sep;
+  assignChairOrSecretary: Fap;
+  assignFapReviewersToProposal: Fap;
   assignInstrumentsToCall: Call;
+  assignProposalsToFap: Scalars['Boolean']['output'];
   assignProposalsToInstrument: Scalars['Boolean']['output'];
-  assignProposalsToSep: Scalars['Boolean']['output'];
-  assignReviewersToSEP: Sep;
+  assignReviewersToFap: Fap;
   assignScientistsToInstrument: Scalars['Boolean']['output'];
-  assignSepReviewersToProposal: Sep;
   assignToScheduledEvents: Scalars['Boolean']['output'];
   changeProposalsStatus: Scalars['Boolean']['output'];
   cloneGenericTemplate: GenericTemplate;
@@ -876,6 +952,7 @@ export type Mutation = {
   createCall: Call;
   createEquipment: EquipmentResponseWrap;
   createEsi: ExperimentSafetyInput;
+  createFap: Fap;
   createFeedback: Feedback;
   createGenericTemplate: GenericTemplate;
   createGenericTemplateWithCopiedAnswers: Array<GenericTemplate>;
@@ -890,7 +967,6 @@ export type Mutation = {
   createQuestion: Question;
   createQuestionTemplateRelation: Template;
   createQuestionary: Questionary;
-  createSEP: Sep;
   createSample: Sample;
   createSampleEsi: SampleExperimentSafetyInput;
   createScheduledEvent: ScheduledEventResponseWrap;
@@ -904,6 +980,7 @@ export type Mutation = {
   deleteApiAccessToken: Scalars['Boolean']['output'];
   deleteCall: Call;
   deleteEquipmentAssignment: Scalars['Boolean']['output'];
+  deleteFap: Fap;
   deleteFeedback: Feedback;
   deleteGenericTemplate: GenericTemplate;
   deleteInstitution: Institution;
@@ -918,7 +995,6 @@ export type Mutation = {
   deleteProposalWorkflowStatus: Scalars['Boolean']['output'];
   deleteQuestion: Question;
   deleteQuestionTemplateRelation: Template;
-  deleteSEP: Sep;
   deleteSample: Sample;
   deleteSampleEsi: SampleExperimentSafetyInput;
   deleteScheduledEvents: ScheduledEventsResponseWrap;
@@ -943,20 +1019,18 @@ export type Mutation = {
   prepareDB: Array<Scalars['String']['output']>;
   redeemCode: RedeemCode;
   removeAssignedInstrumentFromCall: Call;
-  removeMemberFromSEPProposal: Sep;
-  removeMemberFromSep: Sep;
+  removeMemberFromFap: Fap;
+  removeMemberFromFapProposal: Fap;
+  removeProposalsFromFap: Fap;
   removeProposalsFromInstrument: Scalars['Boolean']['output'];
-  removeProposalsFromSep: Sep;
   removeScientistFromInstrument: Scalars['Boolean']['output'];
   removeUserForReview: Review;
   reopenProposalBooking: ProposalBookingResponseWrap;
   reopenScheduledEvent: ScheduledEventResponseWrap;
-  reorderSepMeetingDecisionProposals: SepMeetingDecision;
+  reorderFapMeetingDecisionProposals: FapMeetingDecision;
   requestFeedback: FeedbackRequest;
-  resetPassword: BasicUserDetails;
-  resetPasswordEmail: Scalars['Boolean']['output'];
   resetSchedulerDb: Scalars['String']['output'];
-  saveSepMeetingDecision: SepMeetingDecision;
+  saveFapMeetingDecision: FapMeetingDecision;
   selectRole: Scalars['String']['output'];
   setActiveTemplate: Scalars['Boolean']['output'];
   setInstrumentAvailabilityTime: Scalars['Boolean']['output'];
@@ -974,6 +1048,9 @@ export type Mutation = {
   updateCall: Call;
   updateEquipment: EquipmentResponseWrap;
   updateEsi: ExperimentSafetyInput;
+  updateFap: Fap;
+  updateFapTimeAllocation: FapProposal;
+  updateFapToCallInstrument: Call;
   updateFeatures: Array<Feature>;
   updateFeedback: Feedback;
   updateGenericTemplate: GenericTemplate;
@@ -981,7 +1058,6 @@ export type Mutation = {
   updateInstrument: Instrument;
   updateInternalReview: InternalReview;
   updateLostTime: LostTimeResponseWrap;
-  updatePassword: BasicUserDetails;
   updatePdfTemplate: PdfTemplate;
   updatePredefinedMessage: PredefinedMessage;
   updateProposal: Proposal;
@@ -991,12 +1067,9 @@ export type Mutation = {
   updateQuestionTemplateRelation: Template;
   updateQuestionTemplateRelationSettings: Template;
   updateReview: Review;
-  updateSEP: Sep;
-  updateSEPTimeAllocation: SepProposal;
   updateSample: Sample;
   updateSampleEsi: SampleExperimentSafetyInput;
   updateScheduledEvent: ScheduledEventResponseWrap;
-  updateSepToCallInstrument: Call;
   updateSettings: Settings;
   updateShipment: Shipment;
   updateTechnicalReviewAssignee: Array<TechnicalReview>;
@@ -1058,8 +1131,8 @@ export type MutationAddTechnicalReviewArgs = {
 
 
 export type MutationAddUserForReviewArgs = {
+  fapID: Scalars['Int']['input'];
   proposalPk: Scalars['Int']['input'];
-  sepID: Scalars['Int']['input'];
   userID: Scalars['Int']['input'];
 };
 
@@ -1090,12 +1163,25 @@ export type MutationAnswerTopicArgs = {
 
 
 export type MutationAssignChairOrSecretaryArgs = {
-  assignChairOrSecretaryToSEPInput: AssignChairOrSecretaryToSepInput;
+  assignChairOrSecretaryToFapInput: AssignChairOrSecretaryToFapInput;
+};
+
+
+export type MutationAssignFapReviewersToProposalArgs = {
+  fapId: Scalars['Int']['input'];
+  memberIds: Array<Scalars['Int']['input']>;
+  proposalPk: Scalars['Int']['input'];
 };
 
 
 export type MutationAssignInstrumentsToCallArgs = {
   assignInstrumentsToCallInput: AssignInstrumentsToCallInput;
+};
+
+
+export type MutationAssignProposalsToFapArgs = {
+  fapId: Scalars['Int']['input'];
+  proposals: Array<ProposalSelectionInput>;
 };
 
 
@@ -1105,28 +1191,15 @@ export type MutationAssignProposalsToInstrumentArgs = {
 };
 
 
-export type MutationAssignProposalsToSepArgs = {
-  proposals: Array<ProposalSelectionInput>;
-  sepId: Scalars['Int']['input'];
-};
-
-
-export type MutationAssignReviewersToSepArgs = {
+export type MutationAssignReviewersToFapArgs = {
+  fapId: Scalars['Int']['input'];
   memberIds: Array<Scalars['Int']['input']>;
-  sepId: Scalars['Int']['input'];
 };
 
 
 export type MutationAssignScientistsToInstrumentArgs = {
   instrumentId: Scalars['Int']['input'];
   scientistIds: Array<Scalars['Int']['input']>;
-};
-
-
-export type MutationAssignSepReviewersToProposalArgs = {
-  memberIds: Array<Scalars['Int']['input']>;
-  proposalPk: Scalars['Int']['input'];
-  sepId: Scalars['Int']['input'];
 };
 
 
@@ -1195,6 +1268,16 @@ export type MutationCreateEsiArgs = {
 };
 
 
+export type MutationCreateFapArgs = {
+  active: Scalars['Boolean']['input'];
+  code: Scalars['String']['input'];
+  customGradeGuide?: InputMaybe<Scalars['Boolean']['input']>;
+  description: Scalars['String']['input'];
+  gradeGuide?: InputMaybe<Scalars['String']['input']>;
+  numberRatingsRequired?: Scalars['Int']['input'];
+};
+
+
 export type MutationCreateFeedbackArgs = {
   scheduledEventId: Scalars['Int']['input'];
 };
@@ -1237,6 +1320,7 @@ export type MutationCreateInternalReviewArgs = {
 
 
 export type MutationCreatePdfTemplateArgs = {
+  dummyData: Scalars['String']['input'];
   templateData: Scalars['String']['input'];
   templateFooter: Scalars['String']['input'];
   templateHeader: Scalars['String']['input'];
@@ -1281,16 +1365,6 @@ export type MutationCreateQuestionTemplateRelationArgs = {
 
 export type MutationCreateQuestionaryArgs = {
   templateId: Scalars['Int']['input'];
-};
-
-
-export type MutationCreateSepArgs = {
-  active: Scalars['Boolean']['input'];
-  code: Scalars['String']['input'];
-  customGradeGuide?: InputMaybe<Scalars['Boolean']['input']>;
-  description: Scalars['String']['input'];
-  gradeGuide?: InputMaybe<Scalars['String']['input']>;
-  numberRatingsRequired?: Scalars['Int']['input'];
 };
 
 
@@ -1379,6 +1453,11 @@ export type MutationDeleteEquipmentAssignmentArgs = {
 };
 
 
+export type MutationDeleteFapArgs = {
+  id: Scalars['Int']['input'];
+};
+
+
 export type MutationDeleteFeedbackArgs = {
   feedbackId: Scalars['Int']['input'];
 };
@@ -1447,11 +1526,6 @@ export type MutationDeleteQuestionArgs = {
 export type MutationDeleteQuestionTemplateRelationArgs = {
   questionId: Scalars['String']['input'];
   templateId: Scalars['Int']['input'];
-};
-
-
-export type MutationDeleteSepArgs = {
-  id: Scalars['Int']['input'];
 };
 
 
@@ -1589,28 +1663,28 @@ export type MutationRemoveAssignedInstrumentFromCallArgs = {
 };
 
 
-export type MutationRemoveMemberFromSepProposalArgs = {
+export type MutationRemoveMemberFromFapArgs = {
+  fapId: Scalars['Int']['input'];
   memberId: Scalars['Int']['input'];
-  proposalPk: Scalars['Int']['input'];
-  sepId: Scalars['Int']['input'];
+  roleId: UserRole;
 };
 
 
-export type MutationRemoveMemberFromSepArgs = {
+export type MutationRemoveMemberFromFapProposalArgs = {
+  fapId: Scalars['Int']['input'];
   memberId: Scalars['Int']['input'];
-  roleId: UserRole;
-  sepId: Scalars['Int']['input'];
+  proposalPk: Scalars['Int']['input'];
+};
+
+
+export type MutationRemoveProposalsFromFapArgs = {
+  fapId: Scalars['Int']['input'];
+  proposalPks: Array<Scalars['Int']['input']>;
 };
 
 
 export type MutationRemoveProposalsFromInstrumentArgs = {
   proposalPks: Array<Scalars['Int']['input']>;
-};
-
-
-export type MutationRemoveProposalsFromSepArgs = {
-  proposalPks: Array<Scalars['Int']['input']>;
-  sepId: Scalars['Int']['input'];
 };
 
 
@@ -1621,8 +1695,8 @@ export type MutationRemoveScientistFromInstrumentArgs = {
 
 
 export type MutationRemoveUserForReviewArgs = {
+  fapId: Scalars['Int']['input'];
   reviewId: Scalars['Int']['input'];
-  sepId: Scalars['Int']['input'];
 };
 
 
@@ -1636,8 +1710,8 @@ export type MutationReopenScheduledEventArgs = {
 };
 
 
-export type MutationReorderSepMeetingDecisionProposalsArgs = {
-  reorderSepMeetingDecisionProposalsInput: ReorderSepMeetingDecisionProposalsInput;
+export type MutationReorderFapMeetingDecisionProposalsArgs = {
+  reorderFapMeetingDecisionProposalsInput: ReorderFapMeetingDecisionProposalsInput;
 };
 
 
@@ -1646,24 +1720,13 @@ export type MutationRequestFeedbackArgs = {
 };
 
 
-export type MutationResetPasswordArgs = {
-  password: Scalars['String']['input'];
-  token: Scalars['String']['input'];
-};
-
-
-export type MutationResetPasswordEmailArgs = {
-  email: Scalars['String']['input'];
-};
-
-
 export type MutationResetSchedulerDbArgs = {
   includeSeeds?: InputMaybe<Scalars['Boolean']['input']>;
 };
 
 
-export type MutationSaveSepMeetingDecisionArgs = {
-  saveSepMeetingDecisionInput: SaveSepMeetingDecisionInput;
+export type MutationSaveFapMeetingDecisionArgs = {
+  saveFapMeetingDecisionInput: SaveFapMeetingDecisionInput;
 };
 
 
@@ -1704,8 +1767,8 @@ export type MutationSetUserNotPlaceholderArgs = {
 
 export type MutationSubmitInstrumentArgs = {
   callId: Scalars['Int']['input'];
+  fapId: Scalars['Int']['input'];
   instrumentId: Scalars['Int']['input'];
-  sepId: Scalars['Int']['input'];
 };
 
 
@@ -1762,6 +1825,29 @@ export type MutationUpdateEsiArgs = {
 };
 
 
+export type MutationUpdateFapArgs = {
+  active: Scalars['Boolean']['input'];
+  code: Scalars['String']['input'];
+  customGradeGuide?: InputMaybe<Scalars['Boolean']['input']>;
+  description: Scalars['String']['input'];
+  gradeGuide?: InputMaybe<Scalars['String']['input']>;
+  id: Scalars['Int']['input'];
+  numberRatingsRequired?: Scalars['Int']['input'];
+};
+
+
+export type MutationUpdateFapTimeAllocationArgs = {
+  fapId: Scalars['Int']['input'];
+  fapTimeAllocation?: InputMaybe<Scalars['Int']['input']>;
+  proposalPk: Scalars['Int']['input'];
+};
+
+
+export type MutationUpdateFapToCallInstrumentArgs = {
+  updateFapToCallInstrumentInput: UpdateFapToCallInstrumentInput;
+};
+
+
 export type MutationUpdateFeaturesArgs = {
   updatedFeaturesInput: UpdateFeaturesInput;
 };
@@ -1807,13 +1893,8 @@ export type MutationUpdateLostTimeArgs = {
 };
 
 
-export type MutationUpdatePasswordArgs = {
-  id: Scalars['Int']['input'];
-  password: Scalars['String']['input'];
-};
-
-
 export type MutationUpdatePdfTemplateArgs = {
+  dummyData?: InputMaybe<Scalars['String']['input']>;
   pdfTemplateId: Scalars['Int']['input'];
   templateData?: InputMaybe<Scalars['String']['input']>;
   templateFooter?: InputMaybe<Scalars['String']['input']>;
@@ -1874,28 +1955,10 @@ export type MutationUpdateQuestionTemplateRelationSettingsArgs = {
 
 export type MutationUpdateReviewArgs = {
   comment: Scalars['String']['input'];
+  fapID: Scalars['Int']['input'];
   grade: Scalars['Float']['input'];
   reviewID: Scalars['Int']['input'];
-  sepID: Scalars['Int']['input'];
   status: ReviewStatus;
-};
-
-
-export type MutationUpdateSepArgs = {
-  active: Scalars['Boolean']['input'];
-  code: Scalars['String']['input'];
-  customGradeGuide?: InputMaybe<Scalars['Boolean']['input']>;
-  description: Scalars['String']['input'];
-  gradeGuide?: InputMaybe<Scalars['String']['input']>;
-  id: Scalars['Int']['input'];
-  numberRatingsRequired?: Scalars['Int']['input'];
-};
-
-
-export type MutationUpdateSepTimeAllocationArgs = {
-  proposalPk: Scalars['Int']['input'];
-  sepId: Scalars['Int']['input'];
-  sepTimeAllocation?: InputMaybe<Scalars['Int']['input']>;
 };
 
 
@@ -1916,11 +1979,6 @@ export type MutationUpdateSampleEsiArgs = {
 
 export type MutationUpdateScheduledEventArgs = {
   updateScheduledEvent: UpdateScheduledEventInput;
-};
-
-
-export type MutationUpdateSepToCallInstrumentArgs = {
-  updateSepToCallInstrumentInput: UpdateSepToCallInstrumentInput;
 };
 
 
@@ -2061,6 +2119,7 @@ export enum PageName {
 export type PdfTemplate = {
   created: Scalars['DateTime']['output'];
   creatorId: Scalars['Int']['output'];
+  dummyData: Scalars['String']['output'];
   pdfTemplateId: Scalars['Int']['output'];
   templateData: Scalars['String']['output'];
   templateFooter: Scalars['String']['output'];
@@ -2071,6 +2130,7 @@ export type PdfTemplate = {
 
 export type PdfTemplatesFilter = {
   creatorId?: InputMaybe<Scalars['Int']['input']>;
+  dummyData?: InputMaybe<Scalars['String']['input']>;
   pdfTemplateData?: InputMaybe<Scalars['String']['input']>;
   pdfTemplateFooter?: InputMaybe<Scalars['String']['input']>;
   pdfTemplateHeader?: InputMaybe<Scalars['String']['input']>;
@@ -2106,6 +2166,8 @@ export type Proposal = {
   commentForManagement: Maybe<Scalars['String']['output']>;
   commentForUser: Maybe<Scalars['String']['output']>;
   created: Scalars['DateTime']['output'];
+  fap: Maybe<Fap>;
+  fapMeetingDecision: Maybe<FapMeetingDecision>;
   finalStatus: Maybe<ProposalEndStatus>;
   genericTemplates: Maybe<Array<GenericTemplate>>;
   instrument: Maybe<Instrument>;
@@ -2123,8 +2185,6 @@ export type Proposal = {
   questionaryId: Scalars['Int']['output'];
   reviews: Maybe<Array<Review>>;
   samples: Maybe<Array<Sample>>;
-  sep: Maybe<Sep>;
-  sepMeetingDecision: Maybe<SepMeetingDecision>;
   status: Maybe<ProposalStatus>;
   statusId: Scalars['Int']['output'];
   submitted: Scalars['Boolean']['output'];
@@ -2304,6 +2364,8 @@ export type ProposalView = {
   allocationTimeUnit: AllocationTimeUnits;
   callId: Scalars['Int']['output'];
   callShortCode: Maybe<Scalars['String']['output']>;
+  fapCode: Maybe<Scalars['String']['output']>;
+  fapId: Maybe<Scalars['Int']['output']>;
   finalStatus: Maybe<ProposalEndStatus>;
   instrumentId: Maybe<Scalars['Int']['output']>;
   instrumentName: Maybe<Scalars['String']['output']>;
@@ -2316,8 +2378,6 @@ export type ProposalView = {
   rankOrder: Maybe<Scalars['Int']['output']>;
   reviewAverage: Maybe<Scalars['Float']['output']>;
   reviewDeviation: Maybe<Scalars['Float']['output']>;
-  sepCode: Maybe<Scalars['String']['output']>;
-  sepId: Maybe<Scalars['Int']['output']>;
   statusDescription: Scalars['String']['output'];
   statusId: Scalars['Int']['output'];
   statusName: Scalars['String']['output'];
@@ -2367,6 +2427,7 @@ export type ProposalsFilter = {
   referenceNumbers?: InputMaybe<Array<Scalars['String']['input']>>;
   reviewer?: InputMaybe<ReviewerFilter>;
   shortCodes?: InputMaybe<Array<Scalars['String']['input']>>;
+  templateIds?: InputMaybe<Array<Scalars['Int']['input']>>;
   text?: InputMaybe<Scalars['String']['input']>;
 };
 
@@ -2422,6 +2483,13 @@ export type Query = {
   esi: Maybe<ExperimentSafetyInput>;
   eventLogs: Maybe<Array<EventLog>>;
   factoryVersion: Scalars['String']['output'];
+  fap: Maybe<Fap>;
+  fapMembers: Maybe<Array<FapReviewer>>;
+  fapProposal: Maybe<FapProposal>;
+  fapProposals: Maybe<Array<FapProposal>>;
+  fapProposalsByInstrument: Maybe<Array<FapProposal>>;
+  fapReviewers: Maybe<Array<FapReviewer>>;
+  faps: Maybe<FapsQueryResult>;
   features: Array<Feature>;
   feedback: Maybe<Feedback>;
   feedbacks: Array<Feedback>;
@@ -2429,6 +2497,7 @@ export type Query = {
   filesMetadata: Array<FileMetadata>;
   genericTemplate: Maybe<GenericTemplate>;
   genericTemplates: Maybe<Array<GenericTemplate>>;
+  getDynamicMultipleChoiceOptions: Maybe<Array<Scalars['String']['output']>>;
   healthCheck: HealthStats;
   institutions: Maybe<Array<Institution>>;
   instrument: Maybe<Instrument>;
@@ -2437,7 +2506,7 @@ export type Query = {
   instrumentScientistHasInstrument: Maybe<Scalars['Boolean']['output']>;
   instrumentScientistProposals: Maybe<ProposalsViewResult>;
   instruments: Maybe<InstrumentsQueryResult>;
-  instrumentsBySep: Maybe<Array<InstrumentWithAvailabilityTime>>;
+  instrumentsByFap: Maybe<Array<InstrumentWithAvailabilityTime>>;
   internalReview: Maybe<InternalReview>;
   internalReviews: Maybe<Array<InternalReview>>;
   isNaturalKeyPresent: Maybe<Scalars['Boolean']['output']>;
@@ -2483,13 +2552,6 @@ export type Query = {
   scheduledEventsCore: Array<ScheduledEventCore>;
   schedulerQueriesAndMutations: Maybe<QueriesAndMutations>;
   schedulerVersion: Scalars['String']['output'];
-  sep: Maybe<Sep>;
-  sepMembers: Maybe<Array<SepReviewer>>;
-  sepProposal: Maybe<SepProposal>;
-  sepProposals: Maybe<Array<SepProposal>>;
-  sepProposalsByInstrument: Maybe<Array<SepProposal>>;
-  sepReviewers: Maybe<Array<SepReviewer>>;
-  seps: Maybe<SePsQueryResult>;
   settings: Array<Settings>;
   shipment: Maybe<Shipment>;
   shipments: Maybe<Array<Shipment>>;
@@ -2603,6 +2665,45 @@ export type QueryEventLogsArgs = {
 };
 
 
+export type QueryFapArgs = {
+  id: Scalars['Int']['input'];
+};
+
+
+export type QueryFapMembersArgs = {
+  fapId: Scalars['Int']['input'];
+};
+
+
+export type QueryFapProposalArgs = {
+  fapId: Scalars['Int']['input'];
+  proposalPk: Scalars['Int']['input'];
+};
+
+
+export type QueryFapProposalsArgs = {
+  callId?: InputMaybe<Scalars['Int']['input']>;
+  fapId: Scalars['Int']['input'];
+};
+
+
+export type QueryFapProposalsByInstrumentArgs = {
+  callId: Scalars['Int']['input'];
+  fapId: Scalars['Int']['input'];
+  instrumentId: Scalars['Int']['input'];
+};
+
+
+export type QueryFapReviewersArgs = {
+  fapId: Scalars['Int']['input'];
+};
+
+
+export type QueryFapsArgs = {
+  filter?: InputMaybe<FapsFilter>;
+};
+
+
 export type QueryFeedbackArgs = {
   feedbackId: Scalars['Int']['input'];
 };
@@ -2630,6 +2731,11 @@ export type QueryGenericTemplateArgs = {
 
 export type QueryGenericTemplatesArgs = {
   filter?: InputMaybe<GenericTemplatesFilter>;
+};
+
+
+export type QueryGetDynamicMultipleChoiceOptionsArgs = {
+  questionId: Scalars['String']['input'];
 };
 
 
@@ -2672,9 +2778,9 @@ export type QueryInstrumentsArgs = {
 };
 
 
-export type QueryInstrumentsBySepArgs = {
+export type QueryInstrumentsByFapArgs = {
   callId: Scalars['Int']['input'];
-  sepId: Scalars['Int']['input'];
+  fapId: Scalars['Int']['input'];
 };
 
 
@@ -2862,45 +2968,6 @@ export type QueryScheduledEventsCoreArgs = {
 };
 
 
-export type QuerySepArgs = {
-  id: Scalars['Int']['input'];
-};
-
-
-export type QuerySepMembersArgs = {
-  sepId: Scalars['Int']['input'];
-};
-
-
-export type QuerySepProposalArgs = {
-  proposalPk: Scalars['Int']['input'];
-  sepId: Scalars['Int']['input'];
-};
-
-
-export type QuerySepProposalsArgs = {
-  callId?: InputMaybe<Scalars['Int']['input']>;
-  sepId: Scalars['Int']['input'];
-};
-
-
-export type QuerySepProposalsByInstrumentArgs = {
-  callId: Scalars['Int']['input'];
-  instrumentId: Scalars['Int']['input'];
-  sepId: Scalars['Int']['input'];
-};
-
-
-export type QuerySepReviewersArgs = {
-  sepId: Scalars['Int']['input'];
-};
-
-
-export type QuerySepsArgs = {
-  filter?: InputMaybe<SePsFilter>;
-};
-
-
 export type QueryShipmentArgs = {
   shipmentId: Scalars['Int']['input'];
 };
@@ -3075,17 +3142,17 @@ export type RemoveAssignedInstrumentFromCallInput = {
   instrumentId: Scalars['Int']['input'];
 };
 
-export type ReorderSepMeetingDecisionProposalsInput = {
+export type ReorderFapMeetingDecisionProposalsInput = {
   proposals: Array<ProposalPkWithRankOrder>;
 };
 
 export type Review = {
   comment: Maybe<Scalars['String']['output']>;
+  fapID: Scalars['Int']['output'];
   grade: Maybe<Scalars['Float']['output']>;
   id: Scalars['Int']['output'];
   proposal: Maybe<Proposal>;
   reviewer: Maybe<BasicUserDetails>;
-  sepID: Scalars['Int']['output'];
   status: ReviewStatus;
   userID: Scalars['Int']['output'];
 };
@@ -3111,66 +3178,6 @@ export type Role = {
   id: Scalars['Int']['output'];
   shortCode: Scalars['String']['output'];
   title: Scalars['String']['output'];
-};
-
-export type Sep = {
-  active: Scalars['Boolean']['output'];
-  code: Scalars['String']['output'];
-  customGradeGuide: Maybe<Scalars['Boolean']['output']>;
-  description: Scalars['String']['output'];
-  gradeGuide: Maybe<Scalars['String']['output']>;
-  id: Scalars['Int']['output'];
-  numberRatingsRequired: Scalars['Float']['output'];
-  proposalCount: Scalars['Int']['output'];
-  sepChair: Maybe<BasicUserDetails>;
-  sepChairProposalCount: Maybe<Scalars['Int']['output']>;
-  sepSecretary: Maybe<BasicUserDetails>;
-  sepSecretaryProposalCount: Maybe<Scalars['Int']['output']>;
-};
-
-export type SepAssignment = {
-  dateAssigned: Scalars['DateTime']['output'];
-  dateReassigned: Maybe<Scalars['DateTime']['output']>;
-  emailSent: Scalars['Boolean']['output'];
-  proposal: Proposal;
-  proposalPk: Scalars['Int']['output'];
-  reassigned: Scalars['Boolean']['output'];
-  review: Maybe<Review>;
-  role: Maybe<Role>;
-  sepId: Scalars['Int']['output'];
-  sepMemberUserId: Maybe<Scalars['Int']['output']>;
-  user: Maybe<BasicUserDetails>;
-};
-
-export type SepProposal = {
-  assignments: Maybe<Array<SepAssignment>>;
-  dateAssigned: Scalars['DateTime']['output'];
-  instrumentSubmitted: Scalars['Boolean']['output'];
-  proposal: Proposal;
-  proposalPk: Scalars['Int']['output'];
-  sepId: Scalars['Int']['output'];
-  sepTimeAllocation: Maybe<Scalars['Int']['output']>;
-};
-
-export type SepReviewer = {
-  proposalsCount: Scalars['Int']['output'];
-  role: Maybe<Role>;
-  sepId: Scalars['Int']['output'];
-  user: BasicUserDetails;
-  userId: Scalars['Int']['output'];
-};
-
-export type SePsFilter = {
-  active?: InputMaybe<Scalars['Boolean']['input']>;
-  callIds?: InputMaybe<Array<Scalars['Int']['input']>>;
-  filter?: InputMaybe<Scalars['String']['input']>;
-  first?: InputMaybe<Scalars['Int']['input']>;
-  offset?: InputMaybe<Scalars['Int']['input']>;
-};
-
-export type SePsQueryResult = {
-  seps: Array<Sep>;
-  totalCount: Scalars['Int']['output'];
 };
 
 export type Sample = {
@@ -3234,7 +3241,7 @@ export type SamplesFilter = {
   visitId?: InputMaybe<Scalars['Int']['input']>;
 };
 
-export type SaveSepMeetingDecisionInput = {
+export type SaveFapMeetingDecisionInput = {
   commentForManagement?: InputMaybe<Scalars['String']['input']>;
   commentForUser?: InputMaybe<Scalars['String']['input']>;
   proposalPk: Scalars['Int']['input'];
@@ -3329,16 +3336,6 @@ export type SelectionFromOptionsConfig = {
   small_label: Scalars['String']['output'];
   tooltip: Scalars['String']['output'];
   variant: Scalars['String']['output'];
-};
-
-export type SepMeetingDecision = {
-  commentForManagement: Maybe<Scalars['String']['output']>;
-  commentForUser: Maybe<Scalars['String']['output']>;
-  proposalPk: Scalars['Int']['output'];
-  rankOrder: Maybe<Scalars['Int']['output']>;
-  recommendation: Maybe<ProposalEndStatus>;
-  submitted: Scalars['Boolean']['output'];
-  submittedBy: Maybe<Scalars['Int']['output']>;
 };
 
 export type Settings = {
@@ -3624,37 +3621,43 @@ export type UpdateApiAccessTokenInput = {
 };
 
 export type UpdateCallInput = {
-  allocationTimeUnit: AllocationTimeUnits;
-  callEnded?: InputMaybe<Scalars['Int']['input']>;
+  allocationTimeUnit?: InputMaybe<AllocationTimeUnits>;
+  callEnded?: InputMaybe<Scalars['Boolean']['input']>;
   callEndedInternal?: InputMaybe<Scalars['Boolean']['input']>;
+  callFapReviewEnded?: InputMaybe<Scalars['Int']['input']>;
   callReviewEnded?: InputMaybe<Scalars['Int']['input']>;
-  callSEPReviewEnded?: InputMaybe<Scalars['Int']['input']>;
-  cycleComment: Scalars['String']['input'];
+  cycleComment?: InputMaybe<Scalars['String']['input']>;
   description?: InputMaybe<Scalars['String']['input']>;
-  endCall: Scalars['DateTime']['input'];
+  endCall?: InputMaybe<Scalars['DateTime']['input']>;
   endCallInternal?: InputMaybe<Scalars['DateTime']['input']>;
-  endCycle: Scalars['DateTime']['input'];
-  endNotify: Scalars['DateTime']['input'];
-  endReview: Scalars['DateTime']['input'];
-  endSEPReview?: InputMaybe<Scalars['DateTime']['input']>;
+  endCycle?: InputMaybe<Scalars['DateTime']['input']>;
+  endFapReview?: InputMaybe<Scalars['DateTime']['input']>;
+  endNotify?: InputMaybe<Scalars['DateTime']['input']>;
+  endReview?: InputMaybe<Scalars['DateTime']['input']>;
   esiTemplateId?: InputMaybe<Scalars['Int']['input']>;
+  faps?: InputMaybe<Array<Scalars['Int']['input']>>;
   id: Scalars['Int']['input'];
   isActive?: InputMaybe<Scalars['Boolean']['input']>;
   pdfTemplateId?: InputMaybe<Scalars['Int']['input']>;
   proposalSequence?: InputMaybe<Scalars['Int']['input']>;
-  proposalWorkflowId: Scalars['Int']['input'];
+  proposalWorkflowId?: InputMaybe<Scalars['Int']['input']>;
   referenceNumberFormat?: InputMaybe<Scalars['String']['input']>;
-  seps?: InputMaybe<Array<Scalars['Int']['input']>>;
-  shortCode: Scalars['String']['input'];
-  startCall: Scalars['DateTime']['input'];
-  startCycle: Scalars['DateTime']['input'];
-  startNotify: Scalars['DateTime']['input'];
-  startReview: Scalars['DateTime']['input'];
-  startSEPReview?: InputMaybe<Scalars['DateTime']['input']>;
+  shortCode?: InputMaybe<Scalars['String']['input']>;
+  startCall?: InputMaybe<Scalars['DateTime']['input']>;
+  startCycle?: InputMaybe<Scalars['DateTime']['input']>;
+  startFapReview?: InputMaybe<Scalars['DateTime']['input']>;
+  startNotify?: InputMaybe<Scalars['DateTime']['input']>;
+  startReview?: InputMaybe<Scalars['DateTime']['input']>;
   submissionMessage?: InputMaybe<Scalars['String']['input']>;
-  surveyComment: Scalars['String']['input'];
-  templateId: Scalars['Int']['input'];
+  surveyComment?: InputMaybe<Scalars['String']['input']>;
+  templateId?: InputMaybe<Scalars['Int']['input']>;
   title?: InputMaybe<Scalars['String']['input']>;
+};
+
+export type UpdateFapToCallInstrumentInput = {
+  callId: Scalars['Int']['input'];
+  fapId?: InputMaybe<Scalars['Int']['input']>;
+  instrumentId: Scalars['Int']['input'];
 };
 
 export type UpdateFeaturesInput = {
@@ -3708,12 +3711,6 @@ export type UpdateScheduledEventInput = {
   startsAt: Scalars['TzLessDateTime']['input'];
 };
 
-export type UpdateSepToCallInstrumentInput = {
-  callId: Scalars['Int']['input'];
-  instrumentId: Scalars['Int']['input'];
-  sepId?: InputMaybe<Scalars['Int']['input']>;
-};
-
 export type UpdateSettingsInput = {
   description?: InputMaybe<Scalars['String']['input']>;
   settingsId: SettingsId;
@@ -3726,6 +3723,7 @@ export type User = {
   department: Scalars['String']['output'];
   email: Scalars['String']['output'];
   emailVerified: Scalars['Boolean']['output'];
+  faps: Array<Fap>;
   firstname: Scalars['String']['output'];
   gender: Scalars['String']['output'];
   id: Scalars['Int']['output'];
@@ -3742,7 +3740,6 @@ export type User = {
   proposals: Array<Proposal>;
   reviews: Array<Review>;
   roles: Array<Role>;
-  seps: Array<Sep>;
   telephone: Scalars['String']['output'];
   telephone_alt: Maybe<Scalars['String']['output']>;
   updated: Scalars['String']['output'];
@@ -3788,12 +3785,12 @@ export type UserQueryResult = {
 };
 
 export enum UserRole {
+  FAP_CHAIR = 'FAP_CHAIR',
+  FAP_REVIEWER = 'FAP_REVIEWER',
+  FAP_SECRETARY = 'FAP_SECRETARY',
   INSTRUMENT_SCIENTIST = 'INSTRUMENT_SCIENTIST',
   INTERNAL_REVIEWER = 'INTERNAL_REVIEWER',
   SAMPLE_SAFETY_REVIEWER = 'SAMPLE_SAFETY_REVIEWER',
-  SEP_CHAIR = 'SEP_CHAIR',
-  SEP_REVIEWER = 'SEP_REVIEWER',
-  SEP_SECRETARY = 'SEP_SECRETARY',
   USER = 'USER',
   USER_OFFICER = 'USER_OFFICER'
 }
@@ -3935,7 +3932,7 @@ export type GetCallsQuery = { calls: Array<{ id: number, shortCode: string }> | 
 export type GetUserInstrumentsQueryVariables = Exact<{ [key: string]: never; }>;
 
 
-export type GetUserInstrumentsQuery = { userInstruments: { totalCount: number, instruments: Array<{ id: number, name: string }> } | null };
+export type GetUserInstrumentsQuery = { userInstruments: { totalCount: number, instruments: Array<{ id: number, name: string, beamlineManager: { id: number } | null, scientists: Array<{ id: number }> }> } | null };
 
 export type AddLostTimeMutationVariables = Exact<{
   input: AddLostTimeInput;
@@ -4357,6 +4354,12 @@ export const GetUserInstrumentsDocument = gql`
     instruments {
       id
       name
+      beamlineManager {
+        id
+      }
+      scientists {
+        id
+      }
     }
   }
 }

--- a/apps/frontend/src/graphql/instrument/getUserInstruments.graphql
+++ b/apps/frontend/src/graphql/instrument/getUserInstruments.graphql
@@ -4,6 +4,12 @@ query getUserInstruments {
     instruments {
       id
       name
+      beamlineManager {
+        id
+      }
+      scientists {
+        id
+      }
     }
   }
 }

--- a/apps/frontend/src/hooks/instrument/useUserInstruments.ts
+++ b/apps/frontend/src/hooks/instrument/useUserInstruments.ts
@@ -3,9 +3,13 @@ import { useState, useEffect } from 'react';
 import { GetUserInstrumentsQuery } from 'generated/sdk';
 import { useDataApi } from 'hooks/common/useDataApi';
 
-export type PartialInstrument = NonNullable<
-  GetUserInstrumentsQuery['userInstruments']
->['instruments'][0];
+export type PartialInstrument = Pick<
+  NonNullable<GetUserInstrumentsQuery['userInstruments']>['instruments'][0],
+  'id' | 'name'
+> & {
+  beamlineManager?: { id: number } | null;
+  scientists?: Array<{ id: number }> | [] | null;
+};
 
 export default function useUserInstruments() {
   const [loading, setLoading] = useState(true);


### PR DESCRIPTION
<!--- You can leave blank or remove sections which aren't necessary for the PR. -->

## Description

When a user selects one or multiple instruments, of those selected intrument related equipment and local contact will be sorted to the top of the dropdown list.

https://github.com/UserOfficeProject/user-office-core/pull/464 merge is required to pass e2e test

## Motivation and Context

As a user when picking an instrument means the top of the equipment list is those that are for that instrument and the top of the local contact list is instrument scientists on that instrument.

## How Has This Been Tested

- manual test
- e2e test

## Changes


https://github.com/UserOfficeProject/user-office-scheduler/assets/78078898/c7d28e11-cc2c-45f4-b6d0-68a4304b5e62




## Depends on

<!--- Does this PR depend on another PR that should be merged first or at the same time -->


## Tests included/Docs Updated?

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added tests to cover my changes.
- [ ] All relevant doc has been updated
