### PR TITLE
ci(github actions): remove push on merge to develop action, add PR title checker and upgrade used actions

### DIFF
--- a/.github/pr-title-checker-config.json
+++ b/.github/pr-title-checker-config.json
@@ -1,0 +1,15 @@
+{
+  "LABEL": {
+    "name": ""
+  },
+  "CHECKS": {
+    "NOTE": "You can test the regex here: https://regex101.com/r/i99pPo/1",
+    "regexp": "(^(?<type>build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test|BREAKING CHANGE)(?<scope>\\([\\w\\s]+\\)|\\(\\*+\\))?(?<breaking_change>!?): (?<body>([a-z]).+[^.|\\s])$)",
+    "regexpFlags": "gm"
+  },
+  "MESSAGES": {
+    "success": "All OK",
+    "failure": "PR title not following the semantic-release guidelines",
+    "notice": ""
+  }
+}

--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -17,14 +17,14 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - id: extract_branch
         uses: swapActions/get-branch-name@v1
 
       - name: Create backend image tags
         id: meta-backend
-        uses: docker/metadata-action@v4
+        uses: docker/metadata-action@v5
         with:
           images: ghcr.io/userofficeproject/user-office-scheduler-backend
           flavor: latest=true # adds :latest tag to outputs.tags
@@ -34,7 +34,7 @@ jobs:
 
       - name: Create frontend image tags
         id: meta-frontend
-        uses: docker/metadata-action@v4
+        uses: docker/metadata-action@v5
         with:
           images: ghcr.io/userofficeproject/user-office-scheduler-frontend
           flavor: latest=true # adds :latest tag to outputs.tags
@@ -43,10 +43,10 @@ jobs:
             type=raw,value=${{ steps.extract_branch.outputs.branch }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -55,7 +55,7 @@ jobs:
       # Avoid build and push only for 'master' branch because for 'master' we have another action that builds release image
       - name: Build and push backend
         if: steps.extract_branch.outputs.branch != 'master'
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v5
         with:
           context: ./apps/backend
           platforms: linux/amd64,linux/arm64
@@ -66,7 +66,7 @@ jobs:
       # Avoid build and push only for 'master' branch because for 'master' we have another action that builds release image
       - name: Build and push frontend
         if: steps.extract_branch.outputs.branch != 'master'
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v5
         with:
           context: ./apps/frontend
           platforms: linux/amd64,linux/arm64

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -31,18 +31,18 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v2
+      uses: github/codeql-action/init@v3
       with:
         languages: ${{ matrix.language }}
 
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually.
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v2
+      uses: github/codeql-action/autobuild@v3
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v2
+      uses: github/codeql-action/analyze@v3

--- a/.github/workflows/github-tag-and-release.yml
+++ b/.github/workflows/github-tag-and-release.yml
@@ -9,35 +9,33 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Bump version and push tag
         id: tag_version
-        uses: mathieudutour/github-tag-action@v5.5
+        uses: mathieudutour/github-tag-action@v6.2
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Create a GitHub release
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: ncipollo/release-action@v1
         with:
-          tag_name: ${{ steps.tag_version.outputs.new_tag }}
-          release_name: Release ${{ steps.tag_version.outputs.new_tag }}
+          tag: ${{ steps.tag_version.outputs.new_tag }}
+          name: Release ${{ steps.tag_version.outputs.new_tag }}
           body: ${{ steps.tag_version.outputs.changelog }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v3
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push backend
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v5
         with:
           context: ./apps/backend
           file: ./apps/backend/Dockerfile
@@ -47,7 +45,7 @@ jobs:
 
         # Build and push release image tagged with the same tag as github release
       - name: Build and push frontend
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v5
         with:
           context: ./apps/frontend
           file: ./apps/frontend/Dockerfile

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,10 +14,10 @@ jobs:
 
     steps:
       - name: Check out Git repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ env.NODE_VERSION }}
 

--- a/.github/workflows/pr-title-checker.yml
+++ b/.github/workflows/pr-title-checker.yml
@@ -1,0 +1,21 @@
+name: PR Title Checker
+
+on:
+  pull_request:
+    branches: [develop]
+    types:
+      - opened
+      - edited
+      - synchronize
+      - labeled
+      - unlabeled
+
+jobs:
+  check-pr-title:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: thehanimo/pr-title-checker@v1.4.1
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          pass_on_octokit_error: false
+          configuration_path: .github/pr-title-checker-config.json #(optional. defaults to .github/pr-title-checker-config.json)

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -123,16 +123,16 @@ jobs:
 
     steps:
       - name: Check out Git repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ env.NODE_VERSION }}
 
       - name: Cache node_modules
         id: cached-node-modules-root
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: node_modules
           key: node-modules-root-${{ hashFiles('package-lock.json') }}-${{ env.NODE_VERSION }}
@@ -145,7 +145,7 @@ jobs:
 
       - name: Cache backend node_modules
         id: cached-node-modules-backend
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: apps/backend/node_modules
           key: node-modules-backend-${{ hashFiles('apps/backend/package-lock.json') }}-${{ env.NODE_VERSION }}
@@ -156,7 +156,7 @@ jobs:
 
       - name: Cache frontend node_modules
         id: cached-node-modules-frontend
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: apps/frontend/node_modules
           key: node-modules-frontend-${{ hashFiles('apps/frontend/package-lock.json') }}-${{ env.NODE_VERSION }}
@@ -171,30 +171,30 @@ jobs:
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Set up Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ env.NODE_VERSION }}
 
       - name: Restore node_modules
         id: cached-node-modules-root
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: node_modules
           key: node-modules-root-${{ hashFiles('package-lock.json') }}-${{ env.NODE_VERSION }}
 
       - name: Restore backend node_modules
         id: cached-node-modules-backend
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: apps/backend/node_modules
           key: node-modules-backend-${{ hashFiles('apps/backend/package-lock.json') }}-${{ env.NODE_VERSION }}
 
       - name: Restore frontend node_modules
         id: cached-node-modules-frontend
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: apps/frontend/node_modules
           key: node-modules-frontend-${{ hashFiles('apps/frontend/package-lock.json') }}-${{ env.NODE_VERSION }}
@@ -209,16 +209,16 @@ jobs:
     needs: [resolve_dep, install-and-cache]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Set up Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ env.NODE_VERSION }}
 
       - name: Restore backend node_modules
         id: cached-node-modules-backend
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: apps/backend/node_modules
           key: node-modules-backend-${{ hashFiles('apps/backend/package-lock.json') }}-${{ env.NODE_VERSION }}
@@ -254,27 +254,27 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Set up Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ env.NODE_VERSION }}
 
       - name: Restore node_modules
         id: cached-node-modules-root
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: node_modules
           key: node-modules-root-${{ hashFiles('package-lock.json') }}-${{ env.NODE_VERSION }}
 
       - name: Restore backend node_modules
         id: cached-node-modules-backend
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: apps/backend/node_modules
           key: node-modules-backend-${{ hashFiles('apps/backend/package-lock.json') }}-${{ env.NODE_VERSION }}
 
       - name: Restore frontend node_modules
         id: cached-node-modules-frontend
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: apps/frontend/node_modules
           key: node-modules-frontend-${{ hashFiles('apps/frontend/package-lock.json') }}-${{ env.NODE_VERSION }}
@@ -321,53 +321,3 @@ jobs:
         with:
           name: cypress-screenshots
           path: apps/e2e/cypress/screenshots
-
-  push:
-    # The type of runner that the job will run on
-    runs-on: ubuntu-latest
-    # Don't build and push image if dependabot is creating the PR
-    if: github.actor != 'dependabot[bot]'
-    needs: [install-and-cache, e2e]
-    # Steps represent a sequence of tasks that will be executed as part of the job
-    steps:
-      # TODO: Maybe it is a good idea to use some caching mechanism here for building docker images.
-      - uses: actions/checkout@v3
-
-      # For debugging capture the selected branch
-      - name: Branch
-        run: echo "Branch ${{ github.head_ref }}"
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
-
-      - name: Login to GitHub Container Registry
-        # Don't login if dependabot is creating the PR
-        if: ${{ !startsWith(github.head_ref, 'dependabot') }}
-        uses: docker/login-action@v2
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Build and push backend
-        uses: docker/build-push-action@v4
-        with:
-          context: ./apps/backend
-          file: ./apps/backend/Dockerfile
-          platforms: linux/amd64,linux/arm64
-          # Build but don't push if dependabot is creating the PR
-          push: ${{ !startsWith(github.head_ref, 'dependabot') }}
-          tags: ghcr.io/userofficeproject/user-office-scheduler-backend:${{ github.head_ref }}
-
-      - name: Build and push frontend
-        uses: docker/build-push-action@v4
-        with:
-          context: ./apps/frontend
-          file: ./apps/frontend/Dockerfile
-          platforms: linux/amd64,linux/arm64
-          # Build but don't push if dependabot is creating the PR
-          push: ${{ !startsWith(github.head_ref, 'dependabot') }}
-          tags: ghcr.io/userofficeproject/user-office-scheduler-frontend:${{ github.head_ref }}


### PR DESCRIPTION
<!--- You can leave blank or remove sections which aren't necessary for the PR. -->

## Description

This PR aims to do 3 main things:
* Remove push action for branch images
* Add PR title checker action
* Upgrade outdated actions

## Motivation and Context

We don't need the push action on every pull request as we removed that one in the core repository as well. PR checker is nice to have and follow the core repo.

## How Has This Been Tested

- manual tests

## Fixes

<!--- Does this fix a user story, if so add a reference here -->

## Changes

Changes are only in the CI github action files

## Depends on

<!--- Does this PR depend on another PR that should be merged first or at the same time -->


## Tests included/Docs Updated?

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added tests to cover my changes.
- [ ] All relevant doc has been updated
