### PR TITLE
chore: trigger the deployment pipeline only for staging branch

### DIFF
--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -75,6 +75,7 @@ jobs:
           tags: ${{ steps.meta-frontend.outputs.tags }}
 
       - name: Trigger pipeline
+        if: steps.extract_branch.outputs.branch == 'staging'
         uses: swapActions/trigger-swap-deployment@v1
         with:
           repository: ${{ github.event.repository.name }}


### PR DESCRIPTION
Our new development environment does not need to be triggered when a new version is released.