### PR TITLE
chore: upgrade node to v22

### DIFF
--- a/.github/workflows/generate-sdk.yml
+++ b/.github/workflows/generate-sdk.yml
@@ -29,7 +29,7 @@ jobs:
     - name: Set up environment
       uses: actions/setup-node@v4
       with:
-        node-version: '18'
+        node-version: '22'
 
     - name: Start applications
       run: docker compose -f docker-compose.sdk.yml up -d

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -5,7 +5,7 @@ on:
     branches: [develop, master]
 
 env:
-  NODE_VERSION: 18.x
+  NODE_VERSION: 22.x
 
 jobs:
   run-linters:

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -317,7 +317,7 @@ jobs:
 
       - name: Upload cypres screenshots
         if: failure()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: cypress-screenshots
           path: apps/e2e/cypress/screenshots

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -7,7 +7,7 @@ on:
     branches: [develop]
 
 env:
-  NODE_VERSION: 18.x
+  NODE_VERSION: 22.x
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:

--- a/apps/backend/Dockerfile
+++ b/apps/backend/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18.17.1-alpine AS build-stage
+FROM node:22.14.0-alpine AS build-stage
 
 # NOTE: This is needed for multi-platform builds
 RUN apk add --update python3 make g++ && rm -rf /var/cache/apk/*
@@ -18,7 +18,7 @@ COPY --chown=node:node . .
 
 RUN npm run build
 
-FROM node:18.17.1-alpine
+FROM node:22.14.0-alpine
 
 USER node
 

--- a/apps/backend/package-lock.json
+++ b/apps/backend/package-lock.json
@@ -48,7 +48,7 @@
         "@types/jsonwebtoken": "^9.0.2",
         "@types/lodash.merge": "^4.6.7",
         "@types/luxon": "^3.3.0",
-        "@types/node": "^20.3.1",
+        "@types/node": "^22.13.10",
         "@types/validator": "^13.7.17",
         "@types/yup": "^0.29.13",
         "@typescript-eslint/eslint-plugin": "^5.59.11",
@@ -66,8 +66,8 @@
         "typescript": "^4.9.5"
       },
       "engines": {
-        "node": ">=18.0.0",
-        "npm": ">=9.0.0"
+        "node": ">=22.0.0",
+        "npm": ">=10.9.2"
       }
     },
     "node_modules/@acuminous/bitsyntax": {
@@ -3802,9 +3802,13 @@
       "integrity": "sha512-K0VQKziLUWkVKiRVrx4a40iPaxTUefQmjtkQofBkYRcoaaL/8rhwDWww9qWbrgicNOgnpIsMxyNIUM4+n6dUIA=="
     },
     "node_modules/@types/node": {
-      "version": "20.3.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.3.1.tgz",
-      "integrity": "sha512-EhcH/wvidPy1WeML3TtYFGR83UzjxeWRen9V402T8aUGYsCHOmfoisV3ZSg03gAFIbLq8TnWOJ0f4cALtnSEUg=="
+      "version": "22.13.10",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.13.10.tgz",
+      "integrity": "sha512-I6LPUvlRH+O6VRUqYOcMudhaIdUVWfsjnZavnsraHvpBwaEyMN29ry+0UVJhImYL16xsscu0aske3yA+uPOWfw==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.20.0"
+      }
     },
     "node_modules/@types/node-fetch": {
       "version": "2.6.2",
@@ -12145,6 +12149,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/undici-types": {
+      "version": "6.20.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.20.0.tgz",
+      "integrity": "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==",
+      "license": "MIT"
+    },
     "node_modules/unixify": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unixify/-/unixify-1.0.0.tgz",
@@ -15504,9 +15514,12 @@
       "integrity": "sha512-K0VQKziLUWkVKiRVrx4a40iPaxTUefQmjtkQofBkYRcoaaL/8rhwDWww9qWbrgicNOgnpIsMxyNIUM4+n6dUIA=="
     },
     "@types/node": {
-      "version": "20.3.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.3.1.tgz",
-      "integrity": "sha512-EhcH/wvidPy1WeML3TtYFGR83UzjxeWRen9V402T8aUGYsCHOmfoisV3ZSg03gAFIbLq8TnWOJ0f4cALtnSEUg=="
+      "version": "22.13.10",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.13.10.tgz",
+      "integrity": "sha512-I6LPUvlRH+O6VRUqYOcMudhaIdUVWfsjnZavnsraHvpBwaEyMN29ry+0UVJhImYL16xsscu0aske3yA+uPOWfw==",
+      "requires": {
+        "undici-types": "~6.20.0"
+      }
     },
     "@types/node-fetch": {
       "version": "2.6.2",
@@ -21564,6 +21577,11 @@
       "resolved": "https://registry.npmjs.org/unc-path-regex/-/unc-path-regex-0.1.2.tgz",
       "integrity": "sha512-eXL4nmJT7oCpkZsHZUOJo8hcX3GbsiDOa0Qu9F646fi8dT3XuSVopVqAcEiVzSKKH7UoDti23wNX3qGFxcW5Qg==",
       "dev": true
+    },
+    "undici-types": {
+      "version": "6.20.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.20.0.tgz",
+      "integrity": "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg=="
     },
     "unixify": {
       "version": "1.0.0",

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -13,7 +13,6 @@
     "test": "exit 0",
     "prod": "npm run build && node ./build/index.js",
     "dev": "ts-node-dev -r tsconfig-paths/register --respawn -T ./src/index.ts",
-    "debug": "ts-node-dev  --inspect -r tsconfig-paths/register --respawn -T ./src/index.ts",
     "dev:e2e": "wait-on --verbose --interval 5000 --delay 15000 tcp:5433 && ts-node-dev -r tsconfig-paths/register --respawn -T ./src/index.ts",
     "lint": "tsc --noEmit && eslint ./src --ext .js,.ts --quiet",
     "lint:all": "tsc --noEmit && eslint ./src --ext .js,.ts",

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -13,6 +13,7 @@
     "test": "exit 0",
     "prod": "npm run build && node ./build/index.js",
     "dev": "ts-node-dev -r tsconfig-paths/register --respawn -T ./src/index.ts",
+    "debug": "ts-node-dev  --inspect -r tsconfig-paths/register --respawn -T ./src/index.ts",
     "dev:e2e": "wait-on --verbose --interval 5000 --delay 15000 tcp:5433 && ts-node-dev -r tsconfig-paths/register --respawn -T ./src/index.ts",
     "lint": "tsc --noEmit && eslint ./src --ext .js,.ts --quiet",
     "lint:all": "tsc --noEmit && eslint ./src --ext .js,.ts",
@@ -32,8 +33,8 @@
     "bcrypt": "^5.0.1",
     "body-parser": "^1.20.2",
     "class-transformer": "^0.5.1",
-    "cors": "^2.8.5",
     "cookie-parser": "^1.4.7",
+    "cors": "^2.8.5",
     "dotenv": "^16.1.4",
     "express": "^4.21.1",
     "express-jwt": "^8.4.1",
@@ -54,14 +55,14 @@
     "@graphql-codegen/typescript": "^4.0.1",
     "@graphql-codegen/typescript-graphql-request": "^5.0.0",
     "@graphql-codegen/typescript-operations": "^4.0.1",
-    "@types/cors": "^2.8.13",
     "@types/cookie-parser": "^1.4.2",
+    "@types/cors": "^2.8.13",
     "@types/express": "^4.17.17",
-    "@types/jsonwebtoken": "^9.0.2",
     "@types/jest": "^29.5.7",
+    "@types/jsonwebtoken": "^9.0.2",
     "@types/lodash.merge": "^4.6.7",
     "@types/luxon": "^3.3.0",
-    "@types/node": "^20.3.1",
+    "@types/node": "^22.13.10",
     "@types/validator": "^13.7.17",
     "@types/yup": "^0.29.13",
     "@typescript-eslint/eslint-plugin": "^5.59.11",
@@ -79,7 +80,7 @@
     "typescript": "^4.9.5"
   },
   "engines": {
-    "npm": ">=9.0.0",
-    "node": ">=18.0.0"
+    "npm": ">=10.9.2",
+    "node": ">=22.0.0"
   }
 }

--- a/apps/e2e/package-lock.json
+++ b/apps/e2e/package-lock.json
@@ -23,7 +23,7 @@
       "devDependencies": {
         "@cypress/webpack-preprocessor": "^6.0.0",
         "@types/eslint": "^8.44.1",
-        "@types/node": "^20.4.5",
+        "@types/node": "^22.13.10",
         "@typescript-eslint/eslint-plugin": "^6.2.0",
         "@typescript-eslint/parser": "^6.2.0",
         "eslint": "^8.45.0",
@@ -36,8 +36,8 @@
         "ts-loader": "^9.4.4"
       },
       "engines": {
-        "node": ">=18.0.0",
-        "npm": ">=9.0.0"
+        "node": ">=22.0.0",
+        "npm": ">=10.9.2"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -2387,10 +2387,14 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "20.4.5",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.4.5.tgz",
-      "integrity": "sha512-rt40Nk13II9JwQBdeYqmbn2Q6IVTA5uPhvSO+JVqdXw/6/4glI6oR9ezty/A9Hg5u7JH4OmYmuQ+XvjKm0Datg==",
-      "devOptional": true
+      "version": "22.13.10",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.13.10.tgz",
+      "integrity": "sha512-I6LPUvlRH+O6VRUqYOcMudhaIdUVWfsjnZavnsraHvpBwaEyMN29ry+0UVJhImYL16xsscu0aske3yA+uPOWfw==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.20.0"
+      }
     },
     "node_modules/@types/semver": {
       "version": "7.5.0",
@@ -7619,6 +7623,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/undici-types": {
+      "version": "6.20.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.20.0.tgz",
+      "integrity": "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==",
+      "devOptional": true,
+      "license": "MIT"
+    },
     "node_modules/unicode-canonical-property-names-ecmascript": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-2.0.0.tgz",
@@ -9658,10 +9669,13 @@
       "dev": true
     },
     "@types/node": {
-      "version": "20.4.5",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.4.5.tgz",
-      "integrity": "sha512-rt40Nk13II9JwQBdeYqmbn2Q6IVTA5uPhvSO+JVqdXw/6/4glI6oR9ezty/A9Hg5u7JH4OmYmuQ+XvjKm0Datg==",
-      "devOptional": true
+      "version": "22.13.10",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.13.10.tgz",
+      "integrity": "sha512-I6LPUvlRH+O6VRUqYOcMudhaIdUVWfsjnZavnsraHvpBwaEyMN29ry+0UVJhImYL16xsscu0aske3yA+uPOWfw==",
+      "devOptional": true,
+      "requires": {
+        "undici-types": "~6.20.0"
+      }
     },
     "@types/semver": {
       "version": "7.5.0",
@@ -13378,6 +13392,12 @@
         "has-symbols": "^1.0.3",
         "which-boxed-primitive": "^1.0.2"
       }
+    },
+    "undici-types": {
+      "version": "6.20.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.20.0.tgz",
+      "integrity": "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==",
+      "devOptional": true
     },
     "unicode-canonical-property-names-ecmascript": {
       "version": "2.0.0",

--- a/apps/e2e/package.json
+++ b/apps/e2e/package.json
@@ -18,7 +18,7 @@
   "devDependencies": {
     "@cypress/webpack-preprocessor": "^6.0.0",
     "@types/eslint": "^8.44.1",
-    "@types/node": "^20.4.5",
+    "@types/node": "^22.13.10",
     "@typescript-eslint/eslint-plugin": "^6.2.0",
     "@typescript-eslint/parser": "^6.2.0",
     "eslint": "^8.45.0",
@@ -38,7 +38,7 @@
     "cy:run:action": "env TZ=Europe/Stockholm cypress run --e2e --spec \"${CYPRES_SPEC_PATTERN}\""
   },
   "engines": {
-    "npm": ">=9.0.0",
-    "node": ">=18.0.0"
+    "npm": ">=10.9.2",
+    "node": ">=22.0.0"
   }
 }

--- a/apps/frontend/Dockerfile
+++ b/apps/frontend/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18.17.1-alpine AS build-stage
+FROM node:22.14.0-alpine AS build-stage
 
 # NOTE: This is needed for multi-platform builds
 RUN apk add --update python3 make g++ && rm -rf /var/cache/apk/*

--- a/apps/frontend/package-lock.json
+++ b/apps/frontend/package-lock.json
@@ -62,7 +62,7 @@
       "devDependencies": {
         "@faker-js/faker": "^8.0.2",
         "@types/eslint": "^8.40.2",
-        "@types/node": "^20.2.3",
+        "@types/node": "^22.13.10",
         "@typescript-eslint/eslint-plugin": "^5.59.11",
         "@typescript-eslint/parser": "^5.28.0",
         "eslint": "^8.43.0",
@@ -75,8 +75,8 @@
         "prettier": "^2.8.8"
       },
       "engines": {
-        "node": ">=18.0.0",
-        "npm": ">=9.0.0"
+        "node": ">=22.0.0",
+        "npm": ">=10.9.2"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -5812,11 +5812,12 @@
       "integrity": "sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w=="
     },
     "node_modules/@types/node": {
-      "version": "20.9.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.9.0.tgz",
-      "integrity": "sha512-nekiGu2NDb1BcVofVcEKMIwzlx4NjHlcjhoxxKBNLtz15Y1z7MYf549DFvkHSId02Ax6kGwWntIBPC3l/JZcmw==",
+      "version": "22.13.10",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.13.10.tgz",
+      "integrity": "sha512-I6LPUvlRH+O6VRUqYOcMudhaIdUVWfsjnZavnsraHvpBwaEyMN29ry+0UVJhImYL16xsscu0aske3yA+uPOWfw==",
+      "license": "MIT",
       "dependencies": {
-        "undici-types": "~5.26.4"
+        "undici-types": "~6.20.0"
       }
     },
     "node_modules/@types/node-forge": {
@@ -19477,9 +19478,10 @@
       "integrity": "sha512-hEQt0+ZLDVUMhebKxL4x1BTtDY7bavVofhZ9KZ4aI26X9SRaE+Y3m83XUL1UP2jn8ynjndwCCpEHdUG+9pP1Tw=="
     },
     "node_modules/undici-types": {
-      "version": "5.26.5",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
+      "version": "6.20.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.20.0.tgz",
+      "integrity": "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==",
+      "license": "MIT"
     },
     "node_modules/unicode-canonical-property-names-ecmascript": {
       "version": "2.0.0",

--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -86,7 +86,7 @@
   "devDependencies": {
     "@faker-js/faker": "^8.0.2",
     "@types/eslint": "^8.40.2",
-    "@types/node": "^20.2.3",
+    "@types/node": "^22.13.10",
     "@typescript-eslint/eslint-plugin": "^5.59.11",
     "@typescript-eslint/parser": "^5.28.0",
     "eslint": "^8.43.0",
@@ -99,7 +99,7 @@
     "prettier": "^2.8.8"
   },
   "engines": {
-    "npm": ">=9.0.0",
-    "node": ">=18.0.0"
+    "npm": ">=10.9.2",
+    "node": ">=22.0.0"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,10 @@
       "devDependencies": {
         "husky": "^9.1.7",
         "lint-staged": "^15.2.11"
+      },
+      "engines": {
+        "node": ">=22.0.0",
+        "npm": ">=10.9.2"
       }
     },
     "node_modules/@hapi/hoek": {

--- a/package.json
+++ b/package.json
@@ -50,5 +50,9 @@
   "devDependencies": {
     "husky": "^9.1.7",
     "lint-staged": "^15.2.11"
+  },
+  "engines": {
+    "npm": ">=10.9.2",
+    "node": ">=22.0.0"
   }
 }


### PR DESCRIPTION
## Description
Upgrades Node.js from 18.x to 22.x across the project, updating all relevant configuration files.

## Motivation and Context
Node 18 reaches end-of-life after April 2025. This upgrade leverages new features, improvements, and security patches to boost performance and security.

## Changes
- Updated Node.js version in GitHub workflows and Dockerfiles.
- Upgraded @types/node in package-lock.json and package.json.
- Adjusted npm and Node.js version requirements in package.json engines.