### PR TITLE
chore: update upload-artifact action to v4 in test-build workflow

### DIFF
--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -317,7 +317,7 @@ jobs:
 
       - name: Upload cypres screenshots
         if: failure()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: cypress-screenshots
           path: apps/e2e/cypress/screenshots


### PR DESCRIPTION
## Description
This update is required because upload-artifact@v3 has been deprecated
