### PR TITLE
build(docker): enable verbose npm ci in frontend and backend Dockerfiles

### DIFF
--- a/apps/backend/Dockerfile
+++ b/apps/backend/Dockerfile
@@ -12,7 +12,7 @@ WORKDIR /home/node/app
 
 COPY --chown=node:node package*.json ./
 
-RUN npm ci --loglevel error --no-fund
+RUN npm ci --verbose --no-fund
 
 COPY --chown=node:node . .
 
@@ -30,7 +30,7 @@ COPY --from=build-stage --chown=node:node /home/node/app/db_patches ./db_patches
 COPY --from=build-stage --chown=node:node /home/node/app/build ./build
 COPY --from=build-stage --chown=node:node /home/node/app/package*.json ./
 
-RUN npm ci --only=production --loglevel error --no-fund
+RUN npm ci --only=production --verbose --no-fund
 
 ARG BUILD_VERSION=<unknown>
 RUN echo $BUILD_VERSION > build-version.txt

--- a/apps/frontend/Dockerfile
+++ b/apps/frontend/Dockerfile
@@ -9,7 +9,7 @@ RUN echo "GENERATE_SOURCEMAP=false" >> .env
 
 COPY package*.json /app/
 
-RUN npm ci --loglevel error --no-fund
+RUN npm ci --verbose --no-fund
 
 COPY ./ ./
 


### PR DESCRIPTION
Enable verbose logging to diagnose CI failures