### PR TITLE
[SWAP-5616] Fix typos in Readme file

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ To be able to start both backend and frontend locally you will need to:
 2. Start the application using `npm run dev` or `npm run start`
 
 ## Check the .env file
-If .env file is not preset during startup of the project, it will be created using example.env file template
+If .env file is not present during startup of the project, it will be created using example.env file template
 The `example.env` and `.env` files are located in `apps/backend` and `apps/frontend` accordingly.
 
 ## Running with docker compose
@@ -42,12 +42,12 @@ Runs the app in the development mode.<br>
 
 - Open [http://localhost:4200](http://localhost:4200) to view the GraphQL playground and schema in the browser.
 - Open [http://localhost:33000](http://localhost:33000) to view the app in the browser.
-- Open [http://localhost:4100](http://localhost:4200) to view the federated(core + scheduler) GraphQL playground and schema in the browser.
+- Open [http://localhost:4100](http://localhost:4100) to view the federated(core + scheduler) GraphQL playground and schema in the browser.
 - Open [http://localhost:3000](http://localhost:3000) to view the core app in the browser.
 
 ### `npm run lint`
 
-Lints typescript code and log if there are any errors.<br>
+Lints typescript code and logs if there are any errors.<br>
 `npm run lint:fix` should be used if you want to fix all auto-fixable errors and warnings.
 
 ## Contribution and release versioning


### PR DESCRIPTION
## Summary

Fixes typos and a documentation error in `README.md` as described in ticket **SWAP-5616**.

## Changes

- Corrected "preset" → "present" in the *Check the .env file* section.
- Corrected "log" → "logs" in the `npm run lint` script description.
- Fixed the federated GraphQL playground link so the URL matches its label (`http://localhost:4100`); it previously pointed to `http://localhost:4200`.

## Why

These are minor documentation fixes to improve clarity and correctness of the README.

Ticket: SWAP-5616

🤖 Generated with [Claude Code](https://claude.com/claude-code)