### PR TITLE
docs: fix typos in README

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,4 +21,4 @@ to release new versions automatically.
 
 All other commit types will trigger no new release.
 
-> **_NOTE:_** When merging the pull requests with `Squash and merge` option on github, the title of the pull request should follow the commit guidelines mentioned above because all the commits are squashed into one commit with title od the PR as a message of the commit. Otherwise when using normal `Merge pull request` the title of the pull request doesn't need to follow the commit guidelines but only the commit messages.
+> **_NOTE:_** When merging the pull requests with `Squash and merge` option on github, the title of the pull request should follow the commit guidelines mentioned above because all the commits are squashed into one commit with title of the PR as a message of the commit. Otherwise when using normal `Merge pull request` the title of the pull request doesn't need to follow the commit guidelines but only the commit messages.

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ To be able to start both backend and frontend locally you will need to:
 2. Start the application using `npm run dev` or `npm run start`
 
 ## Check the .env file
-If .env file is not preset during startup of the project, it will be created using example.env file template
+If .env file is not present during startup of the project, it will be created using example.env file template
 The `example.env` and `.env` files are located in `apps/backend` and `apps/frontend` accordingly.
 
 ## Running with docker compose
@@ -42,12 +42,12 @@ Runs the app in the development mode.<br>
 
 - Open [http://localhost:4200](http://localhost:4200) to view the GraphQL playground and schema in the browser.
 - Open [http://localhost:33000](http://localhost:33000) to view the app in the browser.
-- Open [http://localhost:4100](http://localhost:4200) to view the federated(core + scheduler) GraphQL playground and schema in the browser.
+- Open [http://localhost:4100](http://localhost:4100) to view the federated (core + scheduler) GraphQL playground and schema in the browser.
 - Open [http://localhost:3000](http://localhost:3000) to view the core app in the browser.
 
 ### `npm run lint`
 
-Lints typescript code and log if there are any errors.<br>
+Lints TypeScript code and logs if there are any errors.<br>
 `npm run lint:fix` should be used if you want to fix all auto-fixable errors and warnings.
 
 ## Contribution and release versioning

--- a/README.md
+++ b/README.md
@@ -57,4 +57,3 @@ Please refer to the [Contribution guide](CONTRIBUTING.md) to get information abo
 Happy coding! 👨‍💻
 
 For additional questions reach out to Fredrik Bolmsten (fredrik.bolmsten@ess.eu)
-

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ To be able to start both backend and frontend locally you will need to:
 
 ## Check the .env file
 If .env file is not present during startup of the project, it will be created using example.env file template
-The `example.env` and `.env` files are located in `apps/backend` and `apps/frontend` accordingly.
+The `example.env` and `.env` files are located in `apps/backend` and `apps/frontend` respectively.
 
 ## Running with docker compose
 


### PR DESCRIPTION
## Description
Fixed three typos in the README.md file:
- Corrected "preset" → "present" in the `.env` file section
- Fixed an incorrect link URL: `localhost:4200` → `localhost:4100` for the federated GraphQL playground entry
- Added missing space in "federated(core + scheduler)" → "federated (core + scheduler)"

## Motivation and Context
The README contained a spelling error ("preset" instead of "present") and a broken/misleading markdown link where the display text showed port `4100` but the href pointed to port `4200`, which would have sent users to the wrong endpoint.

## How Has This Been Tested
Changes are documentation-only; verified by reading the updated README and confirming the corrected text and URLs are accurate.

## Fixes

https://jira.ess.eu/browse/SWAP-5617

## Changes
- docs: corrected spelling of "preset" to "present" in the .env section
- docs: fixed localhost URL mismatch in the federated GraphQL playground link (4200 → 4100)
- docs: added missing space in "federated (core + scheduler)"

## Tests included/Docs Updated?

- [ ] I have added tests to cover my changes.
- [x] All relevant doc has been updated
