### PR TITLE
fix: add workflow to sync auto-merge PRs with develop branch

### DIFF
--- a/.github/workflows/sync-auto-merge-prs.yml
+++ b/.github/workflows/sync-auto-merge-prs.yml
@@ -1,0 +1,41 @@
+name: Sync auto-merge PRs with develop
+
+on:
+  schedule:
+    - cron: '0 0-5 * * *'
+  workflow_dispatch:
+
+jobs:
+  sync-one-pr:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Find and sync one behind auto-merge PR
+        env:
+          GH_TOKEN: ${{ secrets.PR_SYNC_PAT }}
+        run: |
+          PR_LIST=$(gh pr list \
+            --repo "$GITHUB_REPOSITORY" \
+            --base develop \
+            --state open \
+            --json number,title,autoMergeRequest,mergeStateStatus)
+
+          BEHIND=$(echo "$PR_LIST" | jq '[.[] | select(
+            .autoMergeRequest != null and
+            .mergeStateStatus == "BEHIND"
+          )]')
+
+          COUNT=$(echo "$BEHIND" | jq 'length')
+          echo "Found $COUNT auto-merge PR(s) behind develop"
+
+          if [ "$COUNT" -eq 0 ]; then
+            echo "Nothing to sync."
+            exit 0
+          fi
+
+          INDEX=$((RANDOM % COUNT))
+          PR_NUMBER=$(echo "$BEHIND" | jq --argjson i "$INDEX" '.[$i].number')
+          PR_TITLE=$(echo "$BEHIND"  | jq -r --argjson i "$INDEX" '.[$i].title')
+
+          echo "Selected PR #$PR_NUMBER: $PR_TITLE"
+          gh pr update-branch "$PR_NUMBER" --repo "$GITHUB_REPOSITORY"
+          echo "Branch updated."


### PR DESCRIPTION
## Description

Adds a nightly GitHub Actions workflow that automatically syncs one randomly-selected auto-merge PR with the `develop` branch each hour during low-traffic hours (00:00–05:00 UTC).

## Motivation and Context

The `develop` branch requires PRs to be up to date before merging. PRs that have been approved and marked for auto-merge can sit blocked overnight simply because `develop` moved forward after approval. This workflow unblocks them incrementally — one per hour — by merging `develop` into the PR branch, which re-triggers CI and allows GitHub's auto-merge to complete the job.

One PR is updated per run (randomly selected) rather than all at once to avoid flooding CI with parallel runs.

## How Has This Been Tested

Tested manually via `workflow_dispatch` trigger from the Actions tab:
- With no qualifying PRs: workflow exits cleanly with "Nothing to sync."
- With qualifying PRs: workflow selects one, calls `gh pr update-branch`, and the PR branch receives a new merge commit from `develop`, re-triggering CI.

## Fixes

N/A

## Changes

- New file: `.github/workflows/sync-auto-merge-prs.yml`
  - Scheduled cron: `0 0-5 * * *` (hourly, midnight–05:00 UTC)
  - Lists open PRs targeting `develop` with auto-merge enabled and `mergeStateStatus == BEHIND`
  - Randomly selects one and calls `gh pr update-branch`
  - Authenticates via `PR_SYNC_PAT` repository secret (PAT with `repo` scope)

## Depends on

Requires the `PR_SYNC_PAT` repository secret to be created in GitHub → Settings → Secrets and variables → Actions before the workflow can authenticate.

## Tests included/Docs Updated?

- [ ] I have added tests to cover my changes.
- [ ] All relevant doc has been updated
