### PR TITLE
refactor(logging): replace logError with logException for event handling errors

### DIFF
--- a/apps/backend/src/decorators/EventBus.ts
+++ b/apps/backend/src/decorators/EventBus.ts
@@ -43,7 +43,7 @@ const EventBusDecorator = (eventType: Event) => {
         eventBus
           .publish(event)
           .catch((e) =>
-            logger.logError(`EventBus publish failed ${event.type}`, e)
+            logger.logException(`EventBus publish failed ${event.type}`, e)
           );
       }
 

--- a/apps/backend/src/events/eventBus.ts
+++ b/apps/backend/src/events/eventBus.ts
@@ -12,9 +12,10 @@ export class EventBus<T extends { type: string }> {
         await handler(event);
       } catch (err) {
         // Something happened, log it and continue
-        logger.logError(`Error handling ${event.type} with handler ${i}`, {
-          error: err,
-        });
+        logger.logException(
+          `Error handling ${event.type} with handler ${i}`,
+          err
+        );
       }
     }
   }


### PR DESCRIPTION
### Description

Event handler errors were being logged as empty objects. `logger.logError` serializes its context argument as plain JSON, and an `Error` instance has non-enumerable properties (`message`, `stack`), so `{ error: err }` came out as `{"error":{}}` — losing the message and stack trace entirely.

Switched both event-handling error paths to `logger.logException`, which is designed to take an `Error` and extract its message and stack.

**Changes:**
- `apps/backend/src/events/eventBus.ts` — handler failures in `EventBus.publish` now use `logException(message, err)` instead of `logError(message, { error: err })`.
- `apps/backend/src/decorators/EventBus.ts` — the `publish` rejection handler now uses `logException` as well.

Behaviour is otherwise unchanged: errors are still swallowed so remaining handlers keep running.

Fixes SWAP-5694.
